### PR TITLE
Refactor: de-duplicate response envelope + pagination (allOf composition)

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -350,42 +350,39 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
-                    $ref: '#/components/schemas/Bootstrap'
-                  lead_sources:
-                    $ref: '#/components/schemas/Lead_source'
-                  statuses:
-                    $ref: '#/components/schemas/Status'
-                  tags:
-                    description: >-
-                      Tags provide a means to classify contacts by however many
-                      tags you choose to attach to them. There are 2 types of
-                      tags, tags and system tags
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
+                      data:
+                        $ref: '#/components/schemas/Bootstrap'
+                      lead_sources:
+                        $ref: '#/components/schemas/Lead_source'
+                      statuses:
+                        $ref: '#/components/schemas/Status'
                       tags:
                         description: >-
-                          An array of custom tags. A custom tag is a user created tag used for categorising contacts
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Tag'
-                      system_tags:
-                        description: >-
-                          An array of system tags. A system tag is a system
-                          generate tag used for categorising contacts
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Tag'
-                  contacts_count:
-                    $ref: '#/components/schemas/Contacts_count'
-                  team_stream:
-                    $ref: '#/components/schemas/Team_stream'
+                          Tags provide a means to classify contacts by however many
+                          tags you choose to attach to them. There are 2 types of
+                          tags, tags and system tags
+                        properties:
+                          tags:
+                            description: >-
+                              An array of custom tags. A custom tag is a user created tag used for categorising contacts
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Tag'
+                          system_tags:
+                            description: >-
+                              An array of system tags. A system tag is a system
+                              generate tag used for categorising contacts
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Tag'
+                      contacts_count:
+                        $ref: '#/components/schemas/Contacts_count'
+                      team_stream:
+                        $ref: '#/components/schemas/Team_stream'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -404,19 +401,16 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      auth_key:
-                        description: New API Key
-                        type: string
-                        example: wbJBo+odEikiDOjdnL+P+0fl+Dbgk84747jFtyOZghs=
+                      data:
+                        properties:
+                          auth_key:
+                            description: New API Key
+                            type: string
+                            example: wbJBo+odEikiDOjdnL+P+0fl+Dbgk84747jFtyOZghs=
         400:
           $ref: '#/components/responses/400'
         401:
@@ -433,19 +427,16 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
-                    type: array
-                    items:
-                      properties:
-                        user:
-                          $ref: '#/components/schemas/User'
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          properties:
+                            user:
+                              $ref: '#/components/schemas/User'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -471,17 +462,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      user:
-                        $ref: '#/components/schemas/User'
+                      data:
+                        properties:
+                          user:
+                            $ref: '#/components/schemas/User'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -531,17 +519,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      user:
-                        $ref: '#/components/schemas/User'
+                      data:
+                        properties:
+                          user:
+                            $ref: '#/components/schemas/User'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -566,17 +551,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Lead_source'
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/Lead_source'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -606,15 +588,12 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
-                    $ref: '#/components/schemas/Lead_source'
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/Lead_source'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -640,15 +619,12 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
-                    $ref: '#/components/schemas/Lead_source'
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/Lead_source'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -679,15 +655,12 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
-                    $ref: '#/components/schemas/Lead_source'
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/Lead_source'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -734,19 +707,16 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
-                    type: array
-                    items:
-                      properties:
-                        status:
-                          $ref: '#/components/schemas/Status'
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          properties:
+                            status:
+                              $ref: '#/components/schemas/Status'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -777,17 +747,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      status:
-                        $ref: '#/components/schemas/Status'
+                      data:
+                        properties:
+                          status:
+                            $ref: '#/components/schemas/Status'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -814,17 +781,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      status:
-                        $ref: '#/components/schemas/Status'
+                      data:
+                        properties:
+                          status:
+                            $ref: '#/components/schemas/Status'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -856,17 +820,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      status:
-                        $ref: '#/components/schemas/Status'
+                      data:
+                        properties:
+                          status:
+                            $ref: '#/components/schemas/Status'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -918,29 +879,26 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      deal_fields:
-                        type: array
-                        items:
-                          properties:
-                            deal_field:
-                              $ref: '#/components/schemas/Deal_field'
-                            total_count:
-                              $ref: '#/components/schemas/Page_data/properties/total_count'
-                            page:
-                              $ref: '#/components/schemas/Page_data/properties/page'
-                            per_page:
-                              $ref: '#/components/schemas/Page_data/properties/per_page'
-                            max_page:
-                              $ref: '#/components/schemas/Page_data/properties/max_page'
+                      data:
+                        properties:
+                          deal_fields:
+                            type: array
+                            items:
+                              properties:
+                                deal_field:
+                                  $ref: '#/components/schemas/Deal_field'
+                                total_count:
+                                  $ref: '#/components/schemas/Page_data/properties/total_count'
+                                page:
+                                  $ref: '#/components/schemas/Page_data/properties/page'
+                                per_page:
+                                  $ref: '#/components/schemas/Page_data/properties/per_page'
+                                max_page:
+                                  $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -971,17 +929,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      deal_field:
-                        $ref: '#/components/schemas/Deal_field'
+                      data:
+                        properties:
+                          deal_field:
+                            $ref: '#/components/schemas/Deal_field'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -1008,17 +963,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      deal_field:
-                        $ref: '#/components/schemas/Deal_field'
+                      data:
+                        properties:
+                          deal_field:
+                            $ref: '#/components/schemas/Deal_field'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -1050,17 +1002,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      deal_field:
-                        $ref: '#/components/schemas/Deal_field'
+                      data:
+                        properties:
+                          deal_field:
+                            $ref: '#/components/schemas/Deal_field'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -1112,29 +1061,26 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      custom_fields:
-                        type: array
-                        items:
-                          properties:
-                            custom_field:
-                              $ref: '#/components/schemas/Custom_field'
-                      total_count:
-                        $ref: '#/components/schemas/Page_data/properties/total_count'
-                      page:
-                        $ref: '#/components/schemas/Page_data/properties/page'
-                      per_page:
-                        $ref: '#/components/schemas/Page_data/properties/per_page'
-                      max_page:
-                        $ref: '#/components/schemas/Page_data/properties/max_page'
+                      data:
+                        properties:
+                          custom_fields:
+                            type: array
+                            items:
+                              properties:
+                                custom_field:
+                                  $ref: '#/components/schemas/Custom_field'
+                          total_count:
+                            $ref: '#/components/schemas/Page_data/properties/total_count'
+                          page:
+                            $ref: '#/components/schemas/Page_data/properties/page'
+                          per_page:
+                            $ref: '#/components/schemas/Page_data/properties/per_page'
+                          max_page:
+                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -1165,17 +1111,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      custom_field:
-                        $ref: '#/components/schemas/Custom_field'
+                      data:
+                        properties:
+                          custom_field:
+                            $ref: '#/components/schemas/Custom_field'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -1202,17 +1145,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      custom_field:
-                        $ref: '#/components/schemas/Custom_field'
+                      data:
+                        properties:
+                          custom_field:
+                            $ref: '#/components/schemas/Custom_field'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -1244,17 +1184,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      custom_field:
-                        $ref: '#/components/schemas/Custom_field'
+                      data:
+                        properties:
+                          custom_field:
+                            $ref: '#/components/schemas/Custom_field'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -1306,29 +1243,26 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      company_fields:
-                        type: array
-                        items:
-                          properties:
-                            company_field:
-                              $ref: '#/components/schemas/Company_field'
-                      total_count:
-                        $ref: '#/components/schemas/Page_data/properties/total_count'
-                      page:
-                        $ref: '#/components/schemas/Page_data/properties/page'
-                      per_page:
-                        $ref: '#/components/schemas/Page_data/properties/per_page'
-                      max_page:
-                        $ref: '#/components/schemas/Page_data/properties/max_page'
+                      data:
+                        properties:
+                          company_fields:
+                            type: array
+                            items:
+                              properties:
+                                company_field:
+                                  $ref: '#/components/schemas/Company_field'
+                          total_count:
+                            $ref: '#/components/schemas/Page_data/properties/total_count'
+                          page:
+                            $ref: '#/components/schemas/Page_data/properties/page'
+                          per_page:
+                            $ref: '#/components/schemas/Page_data/properties/per_page'
+                          max_page:
+                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -1359,17 +1293,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      company_field:
-                        $ref: '#/components/schemas/Company_field'
+                      data:
+                        properties:
+                          company_field:
+                            $ref: '#/components/schemas/Company_field'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -1396,17 +1327,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      company_field:
-                        $ref: '#/components/schemas/Company_field'
+                      data:
+                        properties:
+                          company_field:
+                            $ref: '#/components/schemas/Company_field'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -1438,17 +1366,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      company_field:
-                        $ref: '#/components/schemas/Company_field'
+                      data:
+                        properties:
+                          company_field:
+                            $ref: '#/components/schemas/Company_field'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -1496,21 +1421,18 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      predefined_actions:
-                        type: array
-                        items:
-                          properties:
-                            predefined_action:
-                              $ref: '#/components/schemas/Predefined_action'
+                      data:
+                        properties:
+                          predefined_actions:
+                            type: array
+                            items:
+                              properties:
+                                predefined_action:
+                                  $ref: '#/components/schemas/Predefined_action'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -1541,17 +1463,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      predefined_action:
-                        $ref: '#/components/schemas/Predefined_action'
+                      data:
+                        properties:
+                          predefined_action:
+                            $ref: '#/components/schemas/Predefined_action'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -1578,17 +1497,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      predefined_action:
-                        $ref: '#/components/schemas/Predefined_action'
+                      data:
+                        properties:
+                          predefined_action:
+                            $ref: '#/components/schemas/Predefined_action'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -1620,17 +1536,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      predefined_action:
-                        $ref: '#/components/schemas/Predefined_action'
+                      data:
+                        properties:
+                          predefined_action:
+                            $ref: '#/components/schemas/Predefined_action'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -1678,21 +1591,18 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      predefined_action_groups:
-                        type: array
-                        items:
-                          properties:
-                            predefined_action_group:
-                              $ref: '#/components/schemas/Predefined_action_group'
+                      data:
+                        properties:
+                          predefined_action_groups:
+                            type: array
+                            items:
+                              properties:
+                                predefined_action_group:
+                                  $ref: '#/components/schemas/Predefined_action_group'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -1741,17 +1651,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      predefined_action_group:
-                        $ref: '#/components/schemas/Predefined_action_group'
+                      data:
+                        properties:
+                          predefined_action_group:
+                            $ref: '#/components/schemas/Predefined_action_group'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -1778,17 +1685,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      predefined_action_group:
-                        $ref: '#/components/schemas/Predefined_action_group'
+                      data:
+                        properties:
+                          predefined_action_group:
+                            $ref: '#/components/schemas/Predefined_action_group'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -1838,17 +1742,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      predefined_action_group:
-                        $ref: '#/components/schemas/Predefined_action_group'
+                      data:
+                        properties:
+                          predefined_action_group:
+                            $ref: '#/components/schemas/Predefined_action_group'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -1896,21 +1797,18 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      predefined_items:
-                        type: array
-                        items:
-                          properties:
-                            predefined_item:
-                              $ref: '#/components/schemas/Predefined_item'
+                      data:
+                        properties:
+                          predefined_items:
+                            type: array
+                            items:
+                              properties:
+                                predefined_item:
+                                  $ref: '#/components/schemas/Predefined_item'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -1959,17 +1857,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      predefined_item:
-                        $ref: '#/components/schemas/Predefined_item'
+                      data:
+                        properties:
+                          predefined_item:
+                            $ref: '#/components/schemas/Predefined_item'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -1996,17 +1891,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      predefined_item:
-                        $ref: '#/components/schemas/Predefined_item'
+                      data:
+                        properties:
+                          predefined_item:
+                            $ref: '#/components/schemas/Predefined_item'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -2056,17 +1948,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      predefined_item:
-                        $ref: '#/components/schemas/Predefined_item'
+                      data:
+                        properties:
+                          predefined_item:
+                            $ref: '#/components/schemas/Predefined_item'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -2114,21 +2003,18 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      predefined_item_groups:
-                        type: array
-                        items:
-                          properties:
-                            predefined_item_group:
-                              $ref: '#/components/schemas/Predefined_item_group'
+                      data:
+                        properties:
+                          predefined_item_groups:
+                            type: array
+                            items:
+                              properties:
+                                predefined_item_group:
+                                  $ref: '#/components/schemas/Predefined_item_group'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -2172,17 +2058,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      predefined_item:
-                        $ref: '#/components/schemas/Predefined_item_group'
+                      data:
+                        properties:
+                          predefined_item:
+                            $ref: '#/components/schemas/Predefined_item_group'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -2209,17 +2092,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      predefined_item_group:
-                        $ref: '#/components/schemas/Predefined_item_group'
+                      data:
+                        properties:
+                          predefined_item_group:
+                            $ref: '#/components/schemas/Predefined_item_group'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -2278,29 +2158,26 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      notes:
-                        type: array
-                        items:
-                          properties:
-                            note:
-                              $ref: '#/components/schemas/Note'
-                      total_count:
-                        $ref: '#/components/schemas/Page_data/properties/total_count'
-                      page:
-                        $ref: '#/components/schemas/Page_data/properties/page'
-                      per_page:
-                        $ref: '#/components/schemas/Page_data/properties/per_page'
-                      max_page:
-                        $ref: '#/components/schemas/Page_data/properties/max_page'
+                      data:
+                        properties:
+                          notes:
+                            type: array
+                            items:
+                              properties:
+                                note:
+                                  $ref: '#/components/schemas/Note'
+                          total_count:
+                            $ref: '#/components/schemas/Page_data/properties/total_count'
+                          page:
+                            $ref: '#/components/schemas/Page_data/properties/page'
+                          per_page:
+                            $ref: '#/components/schemas/Page_data/properties/per_page'
+                          max_page:
+                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -2349,17 +2226,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      note:
-                        $ref: '#/components/schemas/Note'
+                      data:
+                        properties:
+                          note:
+                            $ref: '#/components/schemas/Note'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -2386,17 +2260,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      note:
-                        $ref: '#/components/schemas/Note'
+                      data:
+                        properties:
+                          note:
+                            $ref: '#/components/schemas/Note'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -2446,17 +2317,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      note:
-                        $ref: '#/components/schemas/Note'
+                      data:
+                        properties:
+                          note:
+                            $ref: '#/components/schemas/Note'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -2549,17 +2417,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      attachment:
-                        $ref: '#/components/schemas/Attachment'
+                      data:
+                        properties:
+                          attachment:
+                            $ref: '#/components/schemas/Attachment'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -2596,29 +2461,26 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      calls:
-                        type: array
-                        items:
-                          properties:
-                            call:
-                              $ref: '#/components/schemas/Call'
-                      total_count:
-                        $ref: '#/components/schemas/Page_data/properties/total_count'
-                      page:
-                        $ref: '#/components/schemas/Page_data/properties/page'
-                      per_page:
-                        $ref: '#/components/schemas/Page_data/properties/per_page'
-                      max_page:
-                        $ref: '#/components/schemas/Page_data/properties/max_page'
+                      data:
+                        properties:
+                          calls:
+                            type: array
+                            items:
+                              properties:
+                                call:
+                                  $ref: '#/components/schemas/Call'
+                          total_count:
+                            $ref: '#/components/schemas/Page_data/properties/total_count'
+                          page:
+                            $ref: '#/components/schemas/Page_data/properties/page'
+                          per_page:
+                            $ref: '#/components/schemas/Page_data/properties/per_page'
+                          max_page:
+                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -2670,17 +2532,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      call:
-                        $ref: '#/components/schemas/Call'
+                      data:
+                        properties:
+                          call:
+                            $ref: '#/components/schemas/Call'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -2707,17 +2566,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      call:
-                        $ref: '#/components/schemas/Call'
+                      data:
+                        properties:
+                          call:
+                            $ref: '#/components/schemas/Call'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -2770,17 +2626,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      call:
-                        $ref: '#/components/schemas/Call'
+                      data:
+                        properties:
+                          call:
+                            $ref: '#/components/schemas/Call'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -2873,17 +2726,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      attachment:
-                        $ref: '#/components/schemas/Attachment'
+                      data:
+                        properties:
+                          attachment:
+                            $ref: '#/components/schemas/Attachment'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -2912,54 +2762,51 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
-                    type: array
-                    items:
-                      properties:
-                        call_result:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
                           properties:
-                            result:
-                              type: string
-                              format: bson-id
-                              description: ID of the call result
-                              example: interested
-                            text:
-                              type: string
-                              description: Display text of the call result
-                              example: Interested
-                            counts:
-                              type: integer
-                              format: int32
-                              description: The number of calls for the logged API user, with the call result
-                              readOnly: true
-                              example: 5
-                            total_counts:
-                              type: integer
-                              format: int32
-                              description: The number of calls for the entire account, with the call result
-                              readOnly: true
-                              example: 5
-                            team_counts:
-                              type: array
-                              description: The number of calls for each user, with the call result
-                              readOnly: true
-                              items:
-                                properties:
-                                  user_id:
-                                    $ref: '#/components/schemas/User/properties/id'
-                                  counts:
-                                    type: integer
-                                    format: int32
-                                    description: Number of calls for the user, with the call result
-                                    readOnly: true
-                                    example: 4
+                            call_result:
+                              properties:
+                                result:
+                                  type: string
+                                  format: bson-id
+                                  description: ID of the call result
+                                  example: interested
+                                text:
+                                  type: string
+                                  description: Display text of the call result
+                                  example: Interested
+                                counts:
+                                  type: integer
+                                  format: int32
+                                  description: The number of calls for the logged API user, with the call result
+                                  readOnly: true
+                                  example: 5
+                                total_counts:
+                                  type: integer
+                                  format: int32
+                                  description: The number of calls for the entire account, with the call result
+                                  readOnly: true
+                                  example: 5
+                                team_counts:
+                                  type: array
+                                  description: The number of calls for each user, with the call result
+                                  readOnly: true
+                                  items:
+                                    properties:
+                                      user_id:
+                                        $ref: '#/components/schemas/User/properties/id'
+                                      counts:
+                                        type: integer
+                                        format: int32
+                                        description: Number of calls for the user, with the call result
+                                        readOnly: true
+                                        example: 4
         400:
           $ref: '#/components/responses/400'
         401:
@@ -2996,29 +2843,26 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      meetings:
-                        type: array
-                        items:
-                          properties:
-                            meeting:
-                              $ref: '#/components/schemas/Meeting'
-                      total_count:
-                        $ref: '#/components/schemas/Page_data/properties/total_count'
-                      page:
-                        $ref: '#/components/schemas/Page_data/properties/page'
-                      per_page:
-                        $ref: '#/components/schemas/Page_data/properties/per_page'
-                      max_page:
-                        $ref: '#/components/schemas/Page_data/properties/max_page'
+                      data:
+                        properties:
+                          meetings:
+                            type: array
+                            items:
+                              properties:
+                                meeting:
+                                  $ref: '#/components/schemas/Meeting'
+                          total_count:
+                            $ref: '#/components/schemas/Page_data/properties/total_count'
+                          page:
+                            $ref: '#/components/schemas/Page_data/properties/page'
+                          per_page:
+                            $ref: '#/components/schemas/Page_data/properties/per_page'
+                          max_page:
+                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -3066,17 +2910,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      meeting:
-                        $ref: '#/components/schemas/Meeting'
+                      data:
+                        properties:
+                          meeting:
+                            $ref: '#/components/schemas/Meeting'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -3103,17 +2944,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      meeting:
-                        $ref: '#/components/schemas/Meeting'
+                      data:
+                        properties:
+                          meeting:
+                            $ref: '#/components/schemas/Meeting'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -3162,17 +3000,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      meeting:
-                        $ref: '#/components/schemas/Meeting'
+                      data:
+                        properties:
+                          meeting:
+                            $ref: '#/components/schemas/Meeting'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -3265,17 +3100,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      attachment:
-                        $ref: '#/components/schemas/Attachment'
+                      data:
+                        properties:
+                          attachment:
+                            $ref: '#/components/schemas/Attachment'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -3323,36 +3155,33 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      deals:
-                        type: array
-                        items:
-                          properties:
-                            deal:
-                              $ref: '#/components/schemas/Deal'
-                            contacts:
-                              type: array
-                              description: >-
-                                Full `Contact` objects for the deal (primary contact plus linked contacts).
-                                Returned only when `fields=contacts(all)` is supplied.
-                              items:
-                                $ref: '#/components/schemas/Contact'
-                      total_count:
-                        $ref: '#/components/schemas/Page_data/properties/total_count'
-                      page:
-                        $ref: '#/components/schemas/Page_data/properties/page'
-                      per_page:
-                        $ref: '#/components/schemas/Page_data/properties/per_page'
-                      max_page:
-                        $ref: '#/components/schemas/Page_data/properties/max_page'
+                      data:
+                        properties:
+                          deals:
+                            type: array
+                            items:
+                              properties:
+                                deal:
+                                  $ref: '#/components/schemas/Deal'
+                                contacts:
+                                  type: array
+                                  description: >-
+                                    Full `Contact` objects for the deal (primary contact plus linked contacts).
+                                    Returned only when `fields=contacts(all)` is supplied.
+                                  items:
+                                    $ref: '#/components/schemas/Contact'
+                          total_count:
+                            $ref: '#/components/schemas/Page_data/properties/total_count'
+                          page:
+                            $ref: '#/components/schemas/Page_data/properties/page'
+                          per_page:
+                            $ref: '#/components/schemas/Page_data/properties/per_page'
+                          max_page:
+                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -3465,17 +3294,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      deal:
-                        $ref: '#/components/schemas/Deal'
+                      data:
+                        properties:
+                          deal:
+                            $ref: '#/components/schemas/Deal'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -3503,17 +3329,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      deal:
-                        $ref: '#/components/schemas/Deal'
+                      data:
+                        properties:
+                          deal:
+                            $ref: '#/components/schemas/Deal'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -3627,17 +3450,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      deal:
-                        $ref: '#/components/schemas/Deal'
+                      data:
+                        properties:
+                          deal:
+                            $ref: '#/components/schemas/Deal'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -3731,17 +3551,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      attachment:
-                        $ref: '#/components/schemas/Attachment'
+                      data:
+                        properties:
+                          attachment:
+                            $ref: '#/components/schemas/Attachment'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -3794,41 +3611,38 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      quota:
-                        example: 1073741824
-                      display_quota:
-                        example: 1024MB
-                      url:
-                        example: https://s3-us-west-1.amazonaws.com/onepagecrm-ud2-us-west-1/
-                      fields:
+                      data:
                         properties:
-                          key:
-                            example: ''
-                          x-ignore-pattern:
-                            example: '59bacde236aebd7842f8be7x/__timestamp__/${filename}'
-                          acl:
-                            example: private
-                          success_action_status:
-                            example: 201
-                          policy:
-                            example: aBcDe...aBcDe=
-                          x-amz-algorithm:
-                            example: AWS4-HMAC-SHA256
-                          x-amz-credential:
-                            example: ABCDE...ABCDE/20170914/us-west-1/s3/aws4_request
-                          x-amz-date:
-                            example: 20170914T184346Z
-                          x-amz-signature:
-                            example: aBcDe...aBcDe
+                          quota:
+                            example: 1073741824
+                          display_quota:
+                            example: 1024MB
+                          url:
+                            example: https://s3-us-west-1.amazonaws.com/onepagecrm-ud2-us-west-1/
+                          fields:
+                            properties:
+                              key:
+                                example: ''
+                              x-ignore-pattern:
+                                example: '59bacde236aebd7842f8be7x/__timestamp__/${filename}'
+                              acl:
+                                example: private
+                              success_action_status:
+                                example: 201
+                              policy:
+                                example: aBcDe...aBcDe=
+                              x-amz-algorithm:
+                                example: AWS4-HMAC-SHA256
+                              x-amz-credential:
+                                example: ABCDE...ABCDE/20170914/us-west-1/s3/aws4_request
+                              x-amz-date:
+                                example: 20170914T184346Z
+                              x-amz-signature:
+                                example: aBcDe...aBcDe
         400:
           $ref: '#/components/responses/400'
         401:
@@ -3899,17 +3713,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      attachment:
-                        $ref: '#/components/schemas/Attachment'
+                      data:
+                        properties:
+                          attachment:
+                            $ref: '#/components/schemas/Attachment'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -3948,15 +3759,12 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
-                    $ref: '#/components/schemas/Attachment'
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/Attachment'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -4005,15 +3813,12 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
-                    $ref: '#/components/schemas/Attachment'
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/Attachment'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -4040,15 +3845,12 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
-                    $ref: '#/components/schemas/Attachment'
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/Attachment'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -4085,29 +3887,26 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      relationship_types:
-                        type: array
-                        items:
-                          properties:
-                            relationship_type:
-                              $ref: '#/components/schemas/Relationship_Type'
-                      total_count:
-                        $ref: '#/components/schemas/Page_data/properties/total_count'
-                      page:
-                        $ref: '#/components/schemas/Page_data/properties/page'
-                      per_page:
-                        $ref: '#/components/schemas/Page_data/properties/per_page'
-                      max_page:
-                        $ref: '#/components/schemas/Page_data/properties/max_page'
+                      data:
+                        properties:
+                          relationship_types:
+                            type: array
+                            items:
+                              properties:
+                                relationship_type:
+                                  $ref: '#/components/schemas/Relationship_Type'
+                          total_count:
+                            $ref: '#/components/schemas/Page_data/properties/total_count'
+                          page:
+                            $ref: '#/components/schemas/Page_data/properties/page'
+                          per_page:
+                            $ref: '#/components/schemas/Page_data/properties/per_page'
+                          max_page:
+                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -4148,21 +3947,18 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      relationship_types:
-                        type: array
-                        items:
-                          properties:
-                            relationship_type:
-                              $ref: '#/components/schemas/Relationship_Type'
+                      data:
+                        properties:
+                          relationship_types:
+                            type: array
+                            items:
+                              properties:
+                                relationship_type:
+                                  $ref: '#/components/schemas/Relationship_Type'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -4189,17 +3985,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      relationship_type:
-                        $ref: '#/components/schemas/Relationship_Type'
+                      data:
+                        properties:
+                          relationship_type:
+                            $ref: '#/components/schemas/Relationship_Type'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -4246,17 +4039,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      relationship_type:
-                        $ref: '#/components/schemas/Relationship_Type'
+                      data:
+                        properties:
+                          relationship_type:
+                            $ref: '#/components/schemas/Relationship_Type'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -4305,36 +4095,33 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      countries:
-                        type: array
-                        items:
-                          properties:
-                            country:
+                      data:
+                        properties:
+                          countries:
+                            type: array
+                            items:
                               properties:
-                                name:
-                                  type: string
-                                  description: Name of the country
-                                  readOnly: true
-                                  example: Ireland
-                                code:
-                                  type: string
-                                  description: ISO-3166 country code
-                                  readOnly: true
-                                  example: IE
-                                phone_prefix:
-                                  type: string
-                                  description: Phone prefix of the country
-                                  readOnly: true
-                                  example: '+353'
+                                country:
+                                  properties:
+                                    name:
+                                      type: string
+                                      description: Name of the country
+                                      readOnly: true
+                                      example: Ireland
+                                    code:
+                                      type: string
+                                      description: ISO-3166 country code
+                                      readOnly: true
+                                      example: IE
+                                    phone_prefix:
+                                      type: string
+                                      description: Phone prefix of the country
+                                      readOnly: true
+                                      example: '+353'
   /actions:
     get:
       summary: Get a list of actions
@@ -4368,29 +4155,26 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      actions:
-                        type: array
-                        items:
-                          properties:
-                            action:
-                              $ref: '#/components/schemas/Action'
-                      total_count:
-                        $ref: '#/components/schemas/Page_data/properties/total_count'
-                      page:
-                        $ref: '#/components/schemas/Page_data/properties/page'
-                      per_page:
-                        $ref: '#/components/schemas/Page_data/properties/per_page'
-                      max_page:
-                        $ref: '#/components/schemas/Page_data/properties/max_page'
+                      data:
+                        properties:
+                          actions:
+                            type: array
+                            items:
+                              properties:
+                                action:
+                                  $ref: '#/components/schemas/Action'
+                          total_count:
+                            $ref: '#/components/schemas/Page_data/properties/total_count'
+                          page:
+                            $ref: '#/components/schemas/Page_data/properties/page'
+                          per_page:
+                            $ref: '#/components/schemas/Page_data/properties/per_page'
+                          max_page:
+                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -4435,17 +4219,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      action:
-                        $ref: '#/components/schemas/Action'
+                      data:
+                        properties:
+                          action:
+                            $ref: '#/components/schemas/Action'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -4472,17 +4253,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      action:
-                        $ref: '#/components/schemas/Action'
+                      data:
+                        properties:
+                          action:
+                            $ref: '#/components/schemas/Action'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -4535,17 +4313,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      action:
-                        $ref: '#/components/schemas/Action'
+                      data:
+                        properties:
+                          action:
+                            $ref: '#/components/schemas/Action'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -4594,17 +4369,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      action:
-                        $ref: '#/components/schemas/Action'
+                      data:
+                        properties:
+                          action:
+                            $ref: '#/components/schemas/Action'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -4631,17 +4403,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      action:
-                        $ref: '#/components/schemas/Action'
+                      data:
+                        properties:
+                          action:
+                            $ref: '#/components/schemas/Action'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -4668,17 +4437,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      action:
-                        $ref: '#/components/schemas/Action'
+                      data:
+                        properties:
+                          action:
+                            $ref: '#/components/schemas/Action'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -4706,17 +4472,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      action:
-                        $ref: '#/components/schemas/Action'
+                      data:
+                        properties:
+                          action:
+                            $ref: '#/components/schemas/Action'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -4743,17 +4506,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      action:
-                        $ref: '#/components/schemas/Action'
+                      data:
+                        properties:
+                          action:
+                            $ref: '#/components/schemas/Action'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -4787,17 +4547,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      action:
-                        $ref: '#/components/schemas/Action'
+                      data:
+                        properties:
+                          action:
+                            $ref: '#/components/schemas/Action'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -4825,29 +4582,26 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      filters:
-                        type: array
-                        items:
-                          properties:
-                            filter:
-                              $ref: '#/components/schemas/Filter'
-                      total_count:
-                        $ref: '#/components/schemas/Page_data/properties/total_count'
-                      page:
-                        $ref: '#/components/schemas/Page_data/properties/page'
-                      per_page:
-                        $ref: '#/components/schemas/Page_data/properties/per_page'
-                      max_page:
-                        $ref: '#/components/schemas/Page_data/properties/max_page'
+                      data:
+                        properties:
+                          filters:
+                            type: array
+                            items:
+                              properties:
+                                filter:
+                                  $ref: '#/components/schemas/Filter'
+                          total_count:
+                            $ref: '#/components/schemas/Page_data/properties/total_count'
+                          page:
+                            $ref: '#/components/schemas/Page_data/properties/page'
+                          per_page:
+                            $ref: '#/components/schemas/Page_data/properties/per_page'
+                          max_page:
+                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -4875,31 +4629,28 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      filter:
-                        $ref: '#/components/schemas/Filter'
-                      total_count:
-                        $ref: '#/components/schemas/Page_data/properties/total_count'
-                      page:
-                        $ref: '#/components/schemas/Page_data/properties/page'
-                      per_page:
-                        $ref: '#/components/schemas/Page_data/properties/per_page'
-                      max_page:
-                        $ref: '#/components/schemas/Page_data/properties/max_page'
-                      contacts:
-                        type: array
-                        items:
-                          properties:
-                            contact:
-                              $ref: '#/components/schemas/Contact'
+                      data:
+                        properties:
+                          filter:
+                            $ref: '#/components/schemas/Filter'
+                          total_count:
+                            $ref: '#/components/schemas/Page_data/properties/total_count'
+                          page:
+                            $ref: '#/components/schemas/Page_data/properties/page'
+                          per_page:
+                            $ref: '#/components/schemas/Page_data/properties/per_page'
+                          max_page:
+                            $ref: '#/components/schemas/Page_data/properties/max_page'
+                          contacts:
+                            type: array
+                            items:
+                              properties:
+                                contact:
+                                  $ref: '#/components/schemas/Contact'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -4932,29 +4683,26 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      companies:
-                        type: array
-                        items:
-                          properties:
-                            company:
-                              $ref: '#/components/schemas/Company'
-                      total_count:
-                        $ref: '#/components/schemas/Page_data/properties/total_count'
-                      page:
-                        $ref: '#/components/schemas/Page_data/properties/page'
-                      per_page:
-                        $ref: '#/components/schemas/Page_data/properties/per_page'
-                      max_page:
-                        $ref: '#/components/schemas/Page_data/properties/max_page'
+                      data:
+                        properties:
+                          companies:
+                            type: array
+                            items:
+                              properties:
+                                company:
+                                  $ref: '#/components/schemas/Company'
+                          total_count:
+                            $ref: '#/components/schemas/Page_data/properties/total_count'
+                          page:
+                            $ref: '#/components/schemas/Page_data/properties/page'
+                          per_page:
+                            $ref: '#/components/schemas/Page_data/properties/per_page'
+                          max_page:
+                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -4981,17 +4729,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      company:
-                        $ref: '#/components/schemas/Company'
+                      data:
+                        properties:
+                          company:
+                            $ref: '#/components/schemas/Company'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -5051,17 +4796,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      company:
-                        $ref: '#/components/schemas/Company'
+                      data:
+                        properties:
+                          company:
+                            $ref: '#/components/schemas/Company'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -5100,29 +4842,26 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      actions:
-                        type: array
-                        items:
-                          properties:
-                            action:
-                              $ref: '#/components/schemas/Action'
-                      total_count:
-                        $ref: '#/components/schemas/Page_data/properties/total_count'
-                      page:
-                        $ref: '#/components/schemas/Page_data/properties/page'
-                      per_page:
-                        $ref: '#/components/schemas/Page_data/properties/per_page'
-                      max_page:
-                        $ref: '#/components/schemas/Page_data/properties/max_page'
+                      data:
+                        properties:
+                          actions:
+                            type: array
+                            items:
+                              properties:
+                                action:
+                                  $ref: '#/components/schemas/Action'
+                          total_count:
+                            $ref: '#/components/schemas/Page_data/properties/total_count'
+                          page:
+                            $ref: '#/components/schemas/Page_data/properties/page'
+                          per_page:
+                            $ref: '#/components/schemas/Page_data/properties/per_page'
+                          max_page:
+                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -5163,29 +4902,26 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      deals:
-                        type: array
-                        items:
-                          properties:
-                            deal:
-                              $ref: '#/components/schemas/Deal'
-                      total_count:
-                        $ref: '#/components/schemas/Page_data/properties/total_count'
-                      page:
-                        $ref: '#/components/schemas/Page_data/properties/page'
-                      per_page:
-                        $ref: '#/components/schemas/Page_data/properties/per_page'
-                      max_page:
-                        $ref: '#/components/schemas/Page_data/properties/max_page'
+                      data:
+                        properties:
+                          deals:
+                            type: array
+                            items:
+                              properties:
+                                deal:
+                                  $ref: '#/components/schemas/Deal'
+                          total_count:
+                            $ref: '#/components/schemas/Page_data/properties/total_count'
+                          page:
+                            $ref: '#/components/schemas/Page_data/properties/page'
+                          per_page:
+                            $ref: '#/components/schemas/Page_data/properties/per_page'
+                          max_page:
+                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -5221,29 +4957,26 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      notes:
-                        type: array
-                        items:
-                          properties:
-                            note:
-                              $ref: '#/components/schemas/Note'
-                      total_count:
-                        $ref: '#/components/schemas/Page_data/properties/total_count'
-                      page:
-                        $ref: '#/components/schemas/Page_data/properties/page'
-                      per_page:
-                        $ref: '#/components/schemas/Page_data/properties/per_page'
-                      max_page:
-                        $ref: '#/components/schemas/Page_data/properties/max_page'
+                      data:
+                        properties:
+                          notes:
+                            type: array
+                            items:
+                              properties:
+                                note:
+                                  $ref: '#/components/schemas/Note'
+                          total_count:
+                            $ref: '#/components/schemas/Page_data/properties/total_count'
+                          page:
+                            $ref: '#/components/schemas/Page_data/properties/page'
+                          per_page:
+                            $ref: '#/components/schemas/Page_data/properties/per_page'
+                          max_page:
+                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -5279,29 +5012,26 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      calls:
-                        type: array
-                        items:
-                          properties:
-                            call:
-                              $ref: '#/components/schemas/Call'
-                      total_count:
-                        $ref: '#/components/schemas/Page_data/properties/total_count'
-                      page:
-                        $ref: '#/components/schemas/Page_data/properties/page'
-                      per_page:
-                        $ref: '#/components/schemas/Page_data/properties/per_page'
-                      max_page:
-                        $ref: '#/components/schemas/Page_data/properties/max_page'
+                      data:
+                        properties:
+                          calls:
+                            type: array
+                            items:
+                              properties:
+                                call:
+                                  $ref: '#/components/schemas/Call'
+                          total_count:
+                            $ref: '#/components/schemas/Page_data/properties/total_count'
+                          page:
+                            $ref: '#/components/schemas/Page_data/properties/page'
+                          per_page:
+                            $ref: '#/components/schemas/Page_data/properties/per_page'
+                          max_page:
+                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -5337,29 +5067,26 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      meetings:
-                        type: array
-                        items:
-                          properties:
-                            meeting:
-                              $ref: '#/components/schemas/Meeting'
-                      total_count:
-                        $ref: '#/components/schemas/Page_data/properties/total_count'
-                      page:
-                        $ref: '#/components/schemas/Page_data/properties/page'
-                      per_page:
-                        $ref: '#/components/schemas/Page_data/properties/per_page'
-                      max_page:
-                        $ref: '#/components/schemas/Page_data/properties/max_page'
+                      data:
+                        properties:
+                          meetings:
+                            type: array
+                            items:
+                              properties:
+                                meeting:
+                                  $ref: '#/components/schemas/Meeting'
+                          total_count:
+                            $ref: '#/components/schemas/Page_data/properties/total_count'
+                          page:
+                            $ref: '#/components/schemas/Page_data/properties/page'
+                          per_page:
+                            $ref: '#/components/schemas/Page_data/properties/per_page'
+                          max_page:
+                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -5390,54 +5117,51 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      linked_contacts:
-                        type: array
-                        items:
-                          properties:
-                            linked_contact:
+                      data:
+                        properties:
+                          linked_contacts:
+                            type: array
+                            items:
                               properties:
-                                contact:
-                                  $ref: '#/components/schemas/Contact'
-                                next_actions:
-                                  type: array
-                                  items:
-                                    $ref: '#/components/schemas/Action'
-                                next_action:
-                                  $ref: '#/components/schemas/Action'
-                                queued_actions:
-                                  type: array
-                                  items:
-                                    $ref: '#/components/schemas/Action'
-                                next_action_conflicts:
-                                  type: array
-                                  items: {}
-                                  example: []
-                                company:
-                                  $ref: '#/components/schemas/Company'
-                                linked_with:
-                                  type: array
-                                  description: IDs of contacts, to which the contact/company is linked
-                                  items:
-                                    type: string
-                                    format: bson-id
-                                    example: 5aba31e99007ba0f570c92ab
-                      total_count:
-                        $ref: '#/components/schemas/Page_data/properties/total_count'
-                      page:
-                        $ref: '#/components/schemas/Page_data/properties/page'
-                      per_page:
-                        $ref: '#/components/schemas/Page_data/properties/per_page'
-                      max_page:
-                        $ref: '#/components/schemas/Page_data/properties/max_page'
+                                linked_contact:
+                                  properties:
+                                    contact:
+                                      $ref: '#/components/schemas/Contact'
+                                    next_actions:
+                                      type: array
+                                      items:
+                                        $ref: '#/components/schemas/Action'
+                                    next_action:
+                                      $ref: '#/components/schemas/Action'
+                                    queued_actions:
+                                      type: array
+                                      items:
+                                        $ref: '#/components/schemas/Action'
+                                    next_action_conflicts:
+                                      type: array
+                                      items: {}
+                                      example: []
+                                    company:
+                                      $ref: '#/components/schemas/Company'
+                                    linked_with:
+                                      type: array
+                                      description: IDs of contacts, to which the contact/company is linked
+                                      items:
+                                        type: string
+                                        format: bson-id
+                                        example: 5aba31e99007ba0f570c92ab
+                          total_count:
+                            $ref: '#/components/schemas/Page_data/properties/total_count'
+                          page:
+                            $ref: '#/components/schemas/Page_data/properties/page'
+                          per_page:
+                            $ref: '#/components/schemas/Page_data/properties/per_page'
+                          max_page:
+                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -5479,42 +5203,39 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      linked_contact:
+                      data:
                         properties:
-                          contact:
-                            $ref: '#/components/schemas/Contact'
-                          next_actions:
-                            type: array
-                            items:
-                              $ref: '#/components/schemas/Action'
-                          next_action:
-                            $ref: '#/components/schemas/Action'
-                          queued_actions:
-                            type: array
-                            items:
-                              $ref: '#/components/schemas/Action'
-                          next_action_conflicts:
-                            type: array
-                            items: {}
-                            example: []
-                          company:
-                            $ref: '#/components/schemas/Company'
-                          linked_with:
-                            type: array
-                            description: IDs of contacts, to which the contact/company is linked
-                            items:
-                              type: string
-                              format: bson-id
-                              example: 5aba31e99007ba0f570c92ab
+                          linked_contact:
+                            properties:
+                              contact:
+                                $ref: '#/components/schemas/Contact'
+                              next_actions:
+                                type: array
+                                items:
+                                  $ref: '#/components/schemas/Action'
+                              next_action:
+                                $ref: '#/components/schemas/Action'
+                              queued_actions:
+                                type: array
+                                items:
+                                  $ref: '#/components/schemas/Action'
+                              next_action_conflicts:
+                                type: array
+                                items: {}
+                                example: []
+                              company:
+                                $ref: '#/components/schemas/Company'
+                              linked_with:
+                                type: array
+                                description: IDs of contacts, to which the contact/company is linked
+                                items:
+                                  type: string
+                                  format: bson-id
+                                  example: 5aba31e99007ba0f570c92ab
         400:
           $ref: '#/components/responses/400'
         401:
@@ -5582,17 +5303,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      company:
-                        $ref: '#/components/schemas/Company'
+                      data:
+                        properties:
+                          company:
+                            $ref: '#/components/schemas/Company'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -5618,17 +5336,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      company:
-                        $ref: '#/components/schemas/Company'
+                      data:
+                        properties:
+                          company:
+                            $ref: '#/components/schemas/Company'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -5657,27 +5372,24 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      pinned_attachments:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Attachment'
-                  total_count:
-                    $ref: '#/components/schemas/Page_data/properties/total_count'
-                  page:
-                    $ref: '#/components/schemas/Page_data/properties/page'
-                  per_page:
-                    $ref: '#/components/schemas/Page_data/properties/per_page'
-                  max_page:
-                    $ref: '#/components/schemas/Page_data/properties/max_page'
+                      data:
+                        properties:
+                          pinned_attachments:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Attachment'
+                      total_count:
+                        $ref: '#/components/schemas/Page_data/properties/total_count'
+                      page:
+                        $ref: '#/components/schemas/Page_data/properties/page'
+                      per_page:
+                        $ref: '#/components/schemas/Page_data/properties/per_page'
+                      max_page:
+                        $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -5712,17 +5424,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      company:
-                        $ref: '#/components/schemas/Company'
+                      data:
+                        properties:
+                          company:
+                            $ref: '#/components/schemas/Company'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -5754,17 +5463,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      company:
-                        $ref: '#/components/schemas/Company'
+                      data:
+                        properties:
+                          company:
+                            $ref: '#/components/schemas/Company'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -5826,95 +5532,92 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      contacts:
+                      data:
+                        properties:
+                          contacts:
+                            type: array
+                            items:
+                              properties:
+                                contact:
+                                  $ref: '#/components/schemas/Contact'
+                                next_actions:
+                                  type: array
+                                  items:
+                                    $ref: '#/components/schemas/Action'
+                                next_action:
+                                  $ref: '#/components/schemas/Action'
+                                queued_actions:
+                                  type: array
+                                  items:
+                                    $ref: '#/components/schemas/Action'
+                                next_action_conflicts:
+                                  type: array
+                                  items: {}
+                                  example: []
+                                company:
+                                  $ref: '#/components/schemas/Company'
+                                deals:
+                                  type: array
+                                  description: Returned only when `fields=deals(all)` is supplied. Full deal objects.
+                                  items:
+                                    $ref: '#/components/schemas/Deal'
+                                notes:
+                                  type: array
+                                  description: Returned only when `fields=notes(all)` is supplied. Full note objects.
+                                  items:
+                                    $ref: '#/components/schemas/Note'
+                                calls:
+                                  type: array
+                                  description: Returned only when `fields=calls(all)` is supplied. Full call objects.
+                                  items:
+                                    $ref: '#/components/schemas/Call'
+                                meetings:
+                                  type: array
+                                  description: Returned only when `fields=meetings(all)` is supplied. Full meeting objects.
+                                  items:
+                                    $ref: '#/components/schemas/Meeting'
+                                pinned_attachments:
+                                  type: array
+                                  description: Returned only when `fields=pinned_attachments(all)` is supplied. Full attachment objects.
+                                  items:
+                                    $ref: '#/components/schemas/Attachment'
+                          total_count:
+                            $ref: '#/components/schemas/Page_data/properties/total_count'
+                          page:
+                            $ref: '#/components/schemas/Page_data/properties/page'
+                          per_page:
+                            $ref: '#/components/schemas/Page_data/properties/per_page'
+                          max_page:
+                            $ref: '#/components/schemas/Page_data/properties/max_page'
+                      lead_sources:
                         type: array
                         items:
+                          $ref: '#/components/schemas/Lead_source'
+                      statuses:
+                        type: array
+                        items:
+                          type: object
                           properties:
-                            contact:
-                              $ref: '#/components/schemas/Contact'
-                            next_actions:
-                              type: array
-                              items:
-                                $ref: '#/components/schemas/Action'
-                            next_action:
-                              $ref: '#/components/schemas/Action'
-                            queued_actions:
-                              type: array
-                              items:
-                                $ref: '#/components/schemas/Action'
-                            next_action_conflicts:
-                              type: array
-                              items: {}
-                              example: []
-                            company:
-                              $ref: '#/components/schemas/Company'
-                            deals:
-                              type: array
-                              description: Returned only when `fields=deals(all)` is supplied. Full deal objects.
-                              items:
-                                $ref: '#/components/schemas/Deal'
-                            notes:
-                              type: array
-                              description: Returned only when `fields=notes(all)` is supplied. Full note objects.
-                              items:
-                                $ref: '#/components/schemas/Note'
-                            calls:
-                              type: array
-                              description: Returned only when `fields=calls(all)` is supplied. Full call objects.
-                              items:
-                                $ref: '#/components/schemas/Call'
-                            meetings:
-                              type: array
-                              description: Returned only when `fields=meetings(all)` is supplied. Full meeting objects.
-                              items:
-                                $ref: '#/components/schemas/Meeting'
-                            pinned_attachments:
-                              type: array
-                              description: Returned only when `fields=pinned_attachments(all)` is supplied. Full attachment objects.
-                              items:
-                                $ref: '#/components/schemas/Attachment'
-                      total_count:
-                        $ref: '#/components/schemas/Page_data/properties/total_count'
-                      page:
-                        $ref: '#/components/schemas/Page_data/properties/page'
-                      per_page:
-                        $ref: '#/components/schemas/Page_data/properties/per_page'
-                      max_page:
-                        $ref: '#/components/schemas/Page_data/properties/max_page'
-                  lead_sources:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Lead_source'
-                  statuses:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        status:
-                          $ref: '#/components/schemas/Status'
-                  tags:
-                    properties:
+                            status:
+                              $ref: '#/components/schemas/Status'
                       tags:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Tag'
-                      system_tags:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Tag'
-                  contacts_count:
-                    $ref: '#/components/schemas/Contacts_count'
-                  team_stream:
-                    $ref: '#/components/schemas/Team_stream'
+                        properties:
+                          tags:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Tag'
+                          system_tags:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Tag'
+                      contacts_count:
+                        $ref: '#/components/schemas/Contacts_count'
+                      team_stream:
+                        $ref: '#/components/schemas/Team_stream'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -5994,58 +5697,55 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      contact:
-                        $ref: '#/components/schemas/Contact'
-                      next_actions:
+                      data:
+                        properties:
+                          contact:
+                            $ref: '#/components/schemas/Contact'
+                          next_actions:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Action'
+                          next_action:
+                            $ref: '#/components/schemas/Action'
+                          queued_actions:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Action'
+                          next_action_conflicts:
+                            type: array
+                            items: {}
+                            example: []
+                          company:
+                            $ref: '#/components/schemas/Company'
+                      lead_sources:
                         type: array
                         items:
-                          $ref: '#/components/schemas/Action'
-                      next_action:
-                        $ref: '#/components/schemas/Action'
-                      queued_actions:
+                          $ref: '#/components/schemas/Lead_source'
+                      statuses:
                         type: array
                         items:
-                          $ref: '#/components/schemas/Action'
-                      next_action_conflicts:
-                        type: array
-                        items: {}
-                        example: []
-                      company:
-                        $ref: '#/components/schemas/Company'
-                  lead_sources:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Lead_source'
-                  statuses:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        status:
-                          $ref: '#/components/schemas/Status'
-                  tags:
-                    properties:
+                          type: object
+                          properties:
+                            status:
+                              $ref: '#/components/schemas/Status'
                       tags:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Tag'
-                      system_tags:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Tag'
-                  contacts_count:
-                    $ref: '#/components/schemas/Contacts_count'
-                  team_stream:
-                    $ref: '#/components/schemas/Team_stream'
+                        properties:
+                          tags:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Tag'
+                          system_tags:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Tag'
+                      contacts_count:
+                        $ref: '#/components/schemas/Contacts_count'
+                      team_stream:
+                        $ref: '#/components/schemas/Team_stream'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -6072,33 +5772,30 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      contact:
-                        $ref: '#/components/schemas/Contact'
-                      next_actions:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Action'
-                      next_action:
-                        $ref: '#/components/schemas/Action'
-                      queued_actions:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Action'
-                      next_action_conflicts:
-                        type: array
-                        items: {}
-                        example: []
-                      company:
-                        $ref: '#/components/schemas/Company'
+                      data:
+                        properties:
+                          contact:
+                            $ref: '#/components/schemas/Contact'
+                          next_actions:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Action'
+                          next_action:
+                            $ref: '#/components/schemas/Action'
+                          queued_actions:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Action'
+                          next_action_conflicts:
+                            type: array
+                            items: {}
+                            example: []
+                          company:
+                            $ref: '#/components/schemas/Company'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -6183,58 +5880,55 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      contact:
-                        $ref: '#/components/schemas/Contact'
-                      next_actions:
+                      data:
+                        properties:
+                          contact:
+                            $ref: '#/components/schemas/Contact'
+                          next_actions:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Action'
+                          next_action:
+                            $ref: '#/components/schemas/Action'
+                          queued_actions:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Action'
+                          next_action_conflicts:
+                            type: array
+                            items: {}
+                            example: []
+                          company:
+                            $ref: '#/components/schemas/Company'
+                      lead_sources:
                         type: array
                         items:
-                          $ref: '#/components/schemas/Action'
-                      next_action:
-                        $ref: '#/components/schemas/Action'
-                      queued_actions:
+                          $ref: '#/components/schemas/Lead_source'
+                      statuses:
                         type: array
                         items:
-                          $ref: '#/components/schemas/Action'
-                      next_action_conflicts:
-                        type: array
-                        items: {}
-                        example: []
-                      company:
-                        $ref: '#/components/schemas/Company'
-                  lead_sources:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Lead_source'
-                  statuses:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        status:
-                          $ref: '#/components/schemas/Status'
-                  tags:
-                    properties:
+                          type: object
+                          properties:
+                            status:
+                              $ref: '#/components/schemas/Status'
                       tags:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Tag'
-                      system_tags:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Tag'
-                  contacts_count:
-                    $ref: '#/components/schemas/Contacts_count'
-                  team_stream:
-                    $ref: '#/components/schemas/Team_stream'
+                        properties:
+                          tags:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Tag'
+                          system_tags:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Tag'
+                      contacts_count:
+                        $ref: '#/components/schemas/Contacts_count'
+                      team_stream:
+                        $ref: '#/components/schemas/Team_stream'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -6268,40 +5962,37 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
-                    type: object
-                  lead_sources:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Lead_source'
-                  statuses:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        status:
-                          $ref: '#/components/schemas/Status'
-                  tags:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
+                      data:
+                        type: object
+                      lead_sources:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/Lead_source'
+                      statuses:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            status:
+                              $ref: '#/components/schemas/Status'
                       tags:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Tag'
-                      system_tags:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Tag'
-                  contacts_count:
-                    $ref: '#/components/schemas/Contacts_count'
-                  team_stream:
-                    $ref: '#/components/schemas/Team_stream'
+                        properties:
+                          tags:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Tag'
+                          system_tags:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Tag'
+                      contacts_count:
+                        $ref: '#/components/schemas/Contacts_count'
+                      team_stream:
+                        $ref: '#/components/schemas/Team_stream'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -6343,17 +6034,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      contact:
-                        $ref: '#/components/schemas/Contact'
+                      data:
+                        properties:
+                          contact:
+                            $ref: '#/components/schemas/Contact'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -6395,17 +6083,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      contact:
-                        $ref: '#/components/schemas/Contact'
+                      data:
+                        properties:
+                          contact:
+                            $ref: '#/components/schemas/Contact'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -6431,17 +6116,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      contact:
-                        $ref: '#/components/schemas/Contact'
+                      data:
+                        properties:
+                          contact:
+                            $ref: '#/components/schemas/Contact'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -6468,31 +6150,28 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      filter:
-                        $ref: '#/components/schemas/Filter'
-                      total_count:
-                        $ref: '#/components/schemas/Page_data/properties/total_count'
-                      page:
-                        $ref: '#/components/schemas/Page_data/properties/page'
-                      per_page:
-                        $ref: '#/components/schemas/Page_data/properties/per_page'
-                      max_page:
-                        $ref: '#/components/schemas/Page_data/properties/max_page'
-                      contacts:
-                        type: array
-                        items:
-                          properties:
-                            contact:
-                              $ref: '#/components/schemas/Contact'
+                      data:
+                        properties:
+                          filter:
+                            $ref: '#/components/schemas/Filter'
+                          total_count:
+                            $ref: '#/components/schemas/Page_data/properties/total_count'
+                          page:
+                            $ref: '#/components/schemas/Page_data/properties/page'
+                          per_page:
+                            $ref: '#/components/schemas/Page_data/properties/per_page'
+                          max_page:
+                            $ref: '#/components/schemas/Page_data/properties/max_page'
+                          contacts:
+                            type: array
+                            items:
+                              properties:
+                                contact:
+                                  $ref: '#/components/schemas/Contact'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -6519,40 +6198,37 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
-                    type: object
-                  lead_sources:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Lead_source'
-                  statuses:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        status:
-                          $ref: '#/components/schemas/Status'
-                  tags:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
+                      data:
+                        type: object
+                      lead_sources:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/Lead_source'
+                      statuses:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            status:
+                              $ref: '#/components/schemas/Status'
                       tags:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Tag'
-                      system_tags:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Tag'
-                  contacts_count:
-                    $ref: '#/components/schemas/Contacts_count'
-                  team_stream:
-                    $ref: '#/components/schemas/Team_stream'
+                        properties:
+                          tags:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Tag'
+                          system_tags:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Tag'
+                      contacts_count:
+                        $ref: '#/components/schemas/Contacts_count'
+                      team_stream:
+                        $ref: '#/components/schemas/Team_stream'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -6585,33 +6261,30 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      contact:
-                        $ref: '#/components/schemas/Contact'
-                      next_actions:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Action'
-                      next_action:
-                        $ref: '#/components/schemas/Action'
-                      queued_actions:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Action'
-                      next_action_conflicts:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Action'
-                      company:
-                        $ref: '#/components/schemas/Company'
+                      data:
+                        properties:
+                          contact:
+                            $ref: '#/components/schemas/Contact'
+                          next_actions:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Action'
+                          next_action:
+                            $ref: '#/components/schemas/Action'
+                          queued_actions:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Action'
+                          next_action_conflicts:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Action'
+                          company:
+                            $ref: '#/components/schemas/Company'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -6650,29 +6323,26 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      actions:
-                        type: array
-                        items:
-                          properties:
-                            action:
-                              $ref: '#/components/schemas/Action'
-                      total_count:
-                        $ref: '#/components/schemas/Page_data/properties/total_count'
-                      page:
-                        $ref: '#/components/schemas/Page_data/properties/page'
-                      per_page:
-                        $ref: '#/components/schemas/Page_data/properties/per_page'
-                      max_page:
-                        $ref: '#/components/schemas/Page_data/properties/max_page'
+                      data:
+                        properties:
+                          actions:
+                            type: array
+                            items:
+                              properties:
+                                action:
+                                  $ref: '#/components/schemas/Action'
+                          total_count:
+                            $ref: '#/components/schemas/Page_data/properties/total_count'
+                          page:
+                            $ref: '#/components/schemas/Page_data/properties/page'
+                          per_page:
+                            $ref: '#/components/schemas/Page_data/properties/per_page'
+                          max_page:
+                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -6716,17 +6386,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      action:
-                        $ref: '#/components/schemas/Action'
+                      data:
+                        properties:
+                          action:
+                            $ref: '#/components/schemas/Action'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -6767,29 +6434,26 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      deals:
-                        type: array
-                        items:
-                          properties:
-                            deal:
-                              $ref: '#/components/schemas/Deal'
-                      total_count:
-                        $ref: '#/components/schemas/Page_data/properties/total_count'
-                      page:
-                        $ref: '#/components/schemas/Page_data/properties/page'
-                      per_page:
-                        $ref: '#/components/schemas/Page_data/properties/per_page'
-                      max_page:
-                        $ref: '#/components/schemas/Page_data/properties/max_page'
+                      data:
+                        properties:
+                          deals:
+                            type: array
+                            items:
+                              properties:
+                                deal:
+                                  $ref: '#/components/schemas/Deal'
+                          total_count:
+                            $ref: '#/components/schemas/Page_data/properties/total_count'
+                          page:
+                            $ref: '#/components/schemas/Page_data/properties/page'
+                          per_page:
+                            $ref: '#/components/schemas/Page_data/properties/per_page'
+                          max_page:
+                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -6868,17 +6532,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      deal:
-                        $ref: '#/components/schemas/Deal'
+                      data:
+                        properties:
+                          deal:
+                            $ref: '#/components/schemas/Deal'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -6914,29 +6575,26 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      notes:
-                        type: array
-                        items:
-                          properties:
-                            note:
-                              $ref: '#/components/schemas/Note'
-                      total_count:
-                        $ref: '#/components/schemas/Page_data/properties/total_count'
-                      page:
-                        $ref: '#/components/schemas/Page_data/properties/page'
-                      per_page:
-                        $ref: '#/components/schemas/Page_data/properties/per_page'
-                      max_page:
-                        $ref: '#/components/schemas/Page_data/properties/max_page'
+                      data:
+                        properties:
+                          notes:
+                            type: array
+                            items:
+                              properties:
+                                note:
+                                  $ref: '#/components/schemas/Note'
+                          total_count:
+                            $ref: '#/components/schemas/Page_data/properties/total_count'
+                          page:
+                            $ref: '#/components/schemas/Page_data/properties/page'
+                          per_page:
+                            $ref: '#/components/schemas/Page_data/properties/per_page'
+                          max_page:
+                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -6984,17 +6642,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      note:
-                        $ref: '#/components/schemas/Note'
+                      data:
+                        properties:
+                          note:
+                            $ref: '#/components/schemas/Note'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -7030,29 +6685,26 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      calls:
-                        type: array
-                        items:
-                          properties:
-                            call:
-                              $ref: '#/components/schemas/Call'
-                      total_count:
-                        $ref: '#/components/schemas/Page_data/properties/total_count'
-                      page:
-                        $ref: '#/components/schemas/Page_data/properties/page'
-                      per_page:
-                        $ref: '#/components/schemas/Page_data/properties/per_page'
-                      max_page:
-                        $ref: '#/components/schemas/Page_data/properties/max_page'
+                      data:
+                        properties:
+                          calls:
+                            type: array
+                            items:
+                              properties:
+                                call:
+                                  $ref: '#/components/schemas/Call'
+                          total_count:
+                            $ref: '#/components/schemas/Page_data/properties/total_count'
+                          page:
+                            $ref: '#/components/schemas/Page_data/properties/page'
+                          per_page:
+                            $ref: '#/components/schemas/Page_data/properties/per_page'
+                          max_page:
+                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -7103,17 +6755,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      call:
-                        $ref: '#/components/schemas/Call'
+                      data:
+                        properties:
+                          call:
+                            $ref: '#/components/schemas/Call'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -7149,29 +6798,26 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      meetings:
-                        type: array
-                        items:
-                          properties:
-                            meeting:
-                              $ref: '#/components/schemas/Meeting'
-                      total_count:
-                        $ref: '#/components/schemas/Page_data/properties/total_count'
-                      page:
-                        $ref: '#/components/schemas/Page_data/properties/page'
-                      per_page:
-                        $ref: '#/components/schemas/Page_data/properties/per_page'
-                      max_page:
-                        $ref: '#/components/schemas/Page_data/properties/max_page'
+                      data:
+                        properties:
+                          meetings:
+                            type: array
+                            items:
+                              properties:
+                                meeting:
+                                  $ref: '#/components/schemas/Meeting'
+                          total_count:
+                            $ref: '#/components/schemas/Page_data/properties/total_count'
+                          page:
+                            $ref: '#/components/schemas/Page_data/properties/page'
+                          per_page:
+                            $ref: '#/components/schemas/Page_data/properties/per_page'
+                          max_page:
+                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -7218,17 +6864,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      meeting:
-                        $ref: '#/components/schemas/Meeting'
+                      data:
+                        properties:
+                          meeting:
+                            $ref: '#/components/schemas/Meeting'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -7269,29 +6912,26 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      relationships:
-                        type: array
-                        items:
-                          properties:
-                            relationship:
-                              $ref: '#/components/schemas/Relationship'
-                      total_count:
-                        $ref: '#/components/schemas/Page_data/properties/total_count'
-                      page:
-                        $ref: '#/components/schemas/Page_data/properties/page'
-                      per_page:
-                        $ref: '#/components/schemas/Page_data/properties/per_page'
-                      max_page:
-                        $ref: '#/components/schemas/Page_data/properties/max_page'
+                      data:
+                        properties:
+                          relationships:
+                            type: array
+                            items:
+                              properties:
+                                relationship:
+                                  $ref: '#/components/schemas/Relationship'
+                          total_count:
+                            $ref: '#/components/schemas/Page_data/properties/total_count'
+                          page:
+                            $ref: '#/components/schemas/Page_data/properties/page'
+                          per_page:
+                            $ref: '#/components/schemas/Page_data/properties/per_page'
+                          max_page:
+                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -7351,17 +6991,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      relationship:
-                        $ref: '#/components/schemas/Relationship'
+                      data:
+                        properties:
+                          relationship:
+                            $ref: '#/components/schemas/Relationship'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -7389,17 +7026,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      relationship:
-                        $ref: '#/components/schemas/Relationship'
+                      data:
+                        properties:
+                          relationship:
+                            $ref: '#/components/schemas/Relationship'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -7460,17 +7094,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      relationship:
-                        $ref: '#/components/schemas/Relationship'
+                      data:
+                        properties:
+                          relationship:
+                            $ref: '#/components/schemas/Relationship'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -7529,40 +7160,37 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
-                    type: object
-                  lead_sources:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Lead_source'
-                  statuses:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        status:
-                          $ref: '#/components/schemas/Status'
-                  tags:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
+                      data:
+                        type: object
+                      lead_sources:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/Lead_source'
+                      statuses:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            status:
+                              $ref: '#/components/schemas/Status'
                       tags:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Tag'
-                      system_tags:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Tag'
-                  contacts_count:
-                    $ref: '#/components/schemas/Contacts_count'
-                  team_stream:
-                    $ref: '#/components/schemas/Team_stream'
+                        properties:
+                          tags:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Tag'
+                          system_tags:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Tag'
+                      contacts_count:
+                        $ref: '#/components/schemas/Contacts_count'
+                      team_stream:
+                        $ref: '#/components/schemas/Team_stream'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -7590,40 +7218,37 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
-                    type: object
-                  lead_sources:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Lead_source'
-                  statuses:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        status:
-                          $ref: '#/components/schemas/Status'
-                  tags:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
+                      data:
+                        type: object
+                      lead_sources:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/Lead_source'
+                      statuses:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            status:
+                              $ref: '#/components/schemas/Status'
                       tags:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Tag'
-                      system_tags:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Tag'
-                  contacts_count:
-                    $ref: '#/components/schemas/Contacts_count'
-                  team_stream:
-                    $ref: '#/components/schemas/Team_stream'
+                        properties:
+                          tags:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Tag'
+                          system_tags:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Tag'
+                      contacts_count:
+                        $ref: '#/components/schemas/Contacts_count'
+                      team_stream:
+                        $ref: '#/components/schemas/Team_stream'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -7651,58 +7276,55 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      contact:
-                        $ref: '#/components/schemas/Contact'
-                      next_actions:
+                      data:
+                        properties:
+                          contact:
+                            $ref: '#/components/schemas/Contact'
+                          next_actions:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Action'
+                          next_action:
+                            $ref: '#/components/schemas/Action'
+                          queued_actions:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Action'
+                          next_action_conflicts:
+                            type: array
+                            items: {}
+                            example: []
+                          company:
+                            $ref: '#/components/schemas/Company'
+                      lead_sources:
                         type: array
                         items:
-                          $ref: '#/components/schemas/Action'
-                      next_action:
-                        $ref: '#/components/schemas/Action'
-                      queued_actions:
+                          $ref: '#/components/schemas/Lead_source'
+                      statuses:
                         type: array
                         items:
-                          $ref: '#/components/schemas/Action'
-                      next_action_conflicts:
-                        type: array
-                        items: {}
-                        example: []
-                      company:
-                        $ref: '#/components/schemas/Company'
-                  lead_sources:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Lead_source'
-                  statuses:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        status:
-                          $ref: '#/components/schemas/Status'
-                  tags:
-                    properties:
+                          type: object
+                          properties:
+                            status:
+                              $ref: '#/components/schemas/Status'
                       tags:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Tag'
-                      system_tags:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Tag'
-                  contacts_count:
-                    $ref: '#/components/schemas/Contacts_count'
-                  team_stream:
-                    $ref: '#/components/schemas/Team_stream'
+                        properties:
+                          tags:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Tag'
+                          system_tags:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Tag'
+                      contacts_count:
+                        $ref: '#/components/schemas/Contacts_count'
+                      team_stream:
+                        $ref: '#/components/schemas/Team_stream'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -7730,58 +7352,55 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      contact:
-                        $ref: '#/components/schemas/Contact'
-                      next_actions:
+                      data:
+                        properties:
+                          contact:
+                            $ref: '#/components/schemas/Contact'
+                          next_actions:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Action'
+                          next_action:
+                            $ref: '#/components/schemas/Action'
+                          queued_actions:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Action'
+                          next_action_conflicts:
+                            type: array
+                            items: {}
+                            example: []
+                          company:
+                            $ref: '#/components/schemas/Company'
+                      lead_sources:
                         type: array
                         items:
-                          $ref: '#/components/schemas/Action'
-                      next_action:
-                        $ref: '#/components/schemas/Action'
-                      queued_actions:
+                          $ref: '#/components/schemas/Lead_source'
+                      statuses:
                         type: array
                         items:
-                          $ref: '#/components/schemas/Action'
-                      next_action_conflicts:
-                        type: array
-                        items: {}
-                        example: []
-                      company:
-                        $ref: '#/components/schemas/Company'
-                  lead_sources:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Lead_source'
-                  statuses:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        status:
-                          $ref: '#/components/schemas/Status'
-                  tags:
-                    properties:
+                          type: object
+                          properties:
+                            status:
+                              $ref: '#/components/schemas/Status'
                       tags:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Tag'
-                      system_tags:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Tag'
-                  contacts_count:
-                    $ref: '#/components/schemas/Contacts_count'
-                  team_stream:
-                    $ref: '#/components/schemas/Team_stream'
+                        properties:
+                          tags:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Tag'
+                          system_tags:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Tag'
+                      contacts_count:
+                        $ref: '#/components/schemas/Contacts_count'
+                      team_stream:
+                        $ref: '#/components/schemas/Team_stream'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -7808,58 +7427,55 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      contact:
-                        $ref: '#/components/schemas/Contact'
-                      next_actions:
+                      data:
+                        properties:
+                          contact:
+                            $ref: '#/components/schemas/Contact'
+                          next_actions:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Action'
+                          next_action:
+                            $ref: '#/components/schemas/Action'
+                          queued_actions:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Action'
+                          next_action_conflicts:
+                            type: array
+                            items: {}
+                            example: []
+                          company:
+                            $ref: '#/components/schemas/Company'
+                      lead_sources:
                         type: array
                         items:
-                          $ref: '#/components/schemas/Action'
-                      next_action:
-                        $ref: '#/components/schemas/Action'
-                      queued_actions:
+                          $ref: '#/components/schemas/Lead_source'
+                      statuses:
                         type: array
                         items:
-                          $ref: '#/components/schemas/Action'
-                      next_action_conflicts:
-                        type: array
-                        items: {}
-                        example: []
-                      company:
-                        $ref: '#/components/schemas/Company'
-                  lead_sources:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Lead_source'
-                  statuses:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        status:
-                          $ref: '#/components/schemas/Status'
-                  tags:
-                    properties:
+                          type: object
+                          properties:
+                            status:
+                              $ref: '#/components/schemas/Status'
                       tags:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Tag'
-                      system_tags:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Tag'
-                  contacts_count:
-                    $ref: '#/components/schemas/Contacts_count'
-                  team_stream:
-                    $ref: '#/components/schemas/Team_stream'
+                        properties:
+                          tags:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Tag'
+                          system_tags:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Tag'
+                      contacts_count:
+                        $ref: '#/components/schemas/Contacts_count'
+                      team_stream:
+                        $ref: '#/components/schemas/Team_stream'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -7886,58 +7502,55 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      contact:
-                        $ref: '#/components/schemas/Contact'
-                      next_actions:
+                      data:
+                        properties:
+                          contact:
+                            $ref: '#/components/schemas/Contact'
+                          next_actions:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Action'
+                          next_action:
+                            $ref: '#/components/schemas/Action'
+                          queued_actions:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Action'
+                          next_action_conflicts:
+                            type: array
+                            items: {}
+                            example: []
+                          company:
+                            $ref: '#/components/schemas/Company'
+                      lead_sources:
                         type: array
                         items:
-                          $ref: '#/components/schemas/Action'
-                      next_action:
-                        $ref: '#/components/schemas/Action'
-                      queued_actions:
+                          $ref: '#/components/schemas/Lead_source'
+                      statuses:
                         type: array
                         items:
-                          $ref: '#/components/schemas/Action'
-                      next_action_conflicts:
-                        type: array
-                        items: {}
-                        example: []
-                      company:
-                        $ref: '#/components/schemas/Company'
-                  lead_sources:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Lead_source'
-                  statuses:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        status:
-                          $ref: '#/components/schemas/Status'
-                  tags:
-                    properties:
+                          type: object
+                          properties:
+                            status:
+                              $ref: '#/components/schemas/Status'
                       tags:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Tag'
-                      system_tags:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Tag'
-                  contacts_count:
-                    $ref: '#/components/schemas/Contacts_count'
-                  team_stream:
-                    $ref: '#/components/schemas/Team_stream'
+                        properties:
+                          tags:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Tag'
+                          system_tags:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Tag'
+                      contacts_count:
+                        $ref: '#/components/schemas/Contacts_count'
+                      team_stream:
+                        $ref: '#/components/schemas/Team_stream'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -7977,33 +7590,30 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      contact:
-                        $ref: '#/components/schemas/Contact'
-                      next_actions:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Action'
-                      next_action:
-                        $ref: '#/components/schemas/Action'
-                      queued_actions:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Action'
-                      next_action_conflicts:
-                        type: array
-                        items: {}
-                        example: []
-                      company:
-                        $ref: '#/components/schemas/Company'
+                      data:
+                        properties:
+                          contact:
+                            $ref: '#/components/schemas/Contact'
+                          next_actions:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Action'
+                          next_action:
+                            $ref: '#/components/schemas/Action'
+                          queued_actions:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Action'
+                          next_action_conflicts:
+                            type: array
+                            items: {}
+                            example: []
+                          company:
+                            $ref: '#/components/schemas/Company'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -8042,33 +7652,30 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      contact:
-                        $ref: '#/components/schemas/Contact'
-                      next_actions:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Action'
-                      next_action:
-                        $ref: '#/components/schemas/Action'
-                      queued_actions:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Action'
-                      next_action_conflicts:
-                        type: array
-                        items: {}
-                        example: []
-                      company:
-                        $ref: '#/components/schemas/Company'
+                      data:
+                        properties:
+                          contact:
+                            $ref: '#/components/schemas/Contact'
+                          next_actions:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Action'
+                          next_action:
+                            $ref: '#/components/schemas/Action'
+                          queued_actions:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Action'
+                          next_action_conflicts:
+                            type: array
+                            items: {}
+                            example: []
+                          company:
+                            $ref: '#/components/schemas/Company'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -8095,33 +7702,30 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      contact:
-                        $ref: '#/components/schemas/Contact'
-                      next_actions:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Action'
-                      next_action:
-                        $ref: '#/components/schemas/Action'
-                      queued_actions:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Action'
-                      next_action_conflicts:
-                        type: array
-                        items: {}
-                        example: []
-                      company:
-                        $ref: '#/components/schemas/Company'
+                      data:
+                        properties:
+                          contact:
+                            $ref: '#/components/schemas/Contact'
+                          next_actions:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Action'
+                          next_action:
+                            $ref: '#/components/schemas/Action'
+                          queued_actions:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Action'
+                          next_action_conflicts:
+                            type: array
+                            items: {}
+                            example: []
+                          company:
+                            $ref: '#/components/schemas/Company'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -8163,33 +7767,30 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      contact:
-                        $ref: '#/components/schemas/Contact'
-                      next_actions:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Action'
-                      next_action:
-                        $ref: '#/components/schemas/Action'
-                      queued_actions:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Action'
-                      next_action_conflicts:
-                        type: array
-                        items: {}
-                        example: []
-                      company:
-                        $ref: '#/components/schemas/Company'
+                      data:
+                        properties:
+                          contact:
+                            $ref: '#/components/schemas/Contact'
+                          next_actions:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Action'
+                          next_action:
+                            $ref: '#/components/schemas/Action'
+                          queued_actions:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Action'
+                          next_action_conflicts:
+                            type: array
+                            items: {}
+                            example: []
+                          company:
+                            $ref: '#/components/schemas/Company'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -8217,27 +7818,24 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      pinned_attachments:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Attachment'
-                  total_count:
-                    $ref: '#/components/schemas/Page_data/properties/total_count'
-                  page:
-                    $ref: '#/components/schemas/Page_data/properties/page'
-                  per_page:
-                    $ref: '#/components/schemas/Page_data/properties/per_page'
-                  max_page:
-                    $ref: '#/components/schemas/Page_data/properties/max_page'
+                      data:
+                        properties:
+                          pinned_attachments:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Attachment'
+                      total_count:
+                        $ref: '#/components/schemas/Page_data/properties/total_count'
+                      page:
+                        $ref: '#/components/schemas/Page_data/properties/page'
+                      per_page:
+                        $ref: '#/components/schemas/Page_data/properties/per_page'
+                      max_page:
+                        $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -8265,48 +7863,45 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      contacts:
-                        type: array
-                        items:
-                          properties:
-                            contact:
-                              $ref: '#/components/schemas/Contact'
-                            next_actions:
-                              type: array
-                              items:
-                                $ref: '#/components/schemas/Action'
-                            next_action:
-                              $ref: '#/components/schemas/Action'
-                            queued_actions:
-                              type: array
-                              items:
-                                $ref: '#/components/schemas/Action'
-                            next_action_conflicts:
-                              type: array
-                              items: {}
-                              example: []
-                            company:
-                              $ref: '#/components/schemas/Company'
-                      items_left:
-                        type: integer
-                        format: int32
-                        description: Total number of items left
-                        readOnly: true
-                        example: 32500
-                      next_set_url:
-                        type: string
-                        description: The URL to use to get the next batch of contacts
-                        readOnly: true
-                        example: https://app.onepagecrm.com/api/v3/contacts/cascade/5d2c8ca59b79b2ead94aa425
+                      data:
+                        properties:
+                          contacts:
+                            type: array
+                            items:
+                              properties:
+                                contact:
+                                  $ref: '#/components/schemas/Contact'
+                                next_actions:
+                                  type: array
+                                  items:
+                                    $ref: '#/components/schemas/Action'
+                                next_action:
+                                  $ref: '#/components/schemas/Action'
+                                queued_actions:
+                                  type: array
+                                  items:
+                                    $ref: '#/components/schemas/Action'
+                                next_action_conflicts:
+                                  type: array
+                                  items: {}
+                                  example: []
+                                company:
+                                  $ref: '#/components/schemas/Company'
+                          items_left:
+                            type: integer
+                            format: int32
+                            description: Total number of items left
+                            readOnly: true
+                            example: 32500
+                          next_set_url:
+                            type: string
+                            description: The URL to use to get the next batch of contacts
+                            readOnly: true
+                            example: https://app.onepagecrm.com/api/v3/contacts/cascade/5d2c8ca59b79b2ead94aa425
         400:
           $ref: '#/components/responses/400'
         401:
@@ -8343,48 +7938,45 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      contacts:
-                        type: array
-                        items:
-                          properties:
-                            contact:
-                              $ref: '#/components/schemas/Contact'
-                            next_actions:
-                              type: array
-                              items:
-                                $ref: '#/components/schemas/Action'
-                            next_action:
-                              $ref: '#/components/schemas/Action'
-                            queued_actions:
-                              type: array
-                              items:
-                                $ref: '#/components/schemas/Action'
-                            next_action_conflicts:
-                              type: array
-                              items: {}
-                              example: []
-                            company:
-                              $ref: '#/components/schemas/Company'
-                      items_left:
-                        type: integer
-                        format: int32
-                        description: Total number of items left
-                        readOnly: true
-                        example: 32500
-                      next_set_url:
-                        type: string
-                        description: The URL to use to get the next batch of contacts
-                        readOnly: true
-                        example: https://app.onepagecrm.com/api/v3/contacts/cascade/5d2c8ca59b79b2ead94aa425
+                      data:
+                        properties:
+                          contacts:
+                            type: array
+                            items:
+                              properties:
+                                contact:
+                                  $ref: '#/components/schemas/Contact'
+                                next_actions:
+                                  type: array
+                                  items:
+                                    $ref: '#/components/schemas/Action'
+                                next_action:
+                                  $ref: '#/components/schemas/Action'
+                                queued_actions:
+                                  type: array
+                                  items:
+                                    $ref: '#/components/schemas/Action'
+                                next_action_conflicts:
+                                  type: array
+                                  items: {}
+                                  example: []
+                                company:
+                                  $ref: '#/components/schemas/Company'
+                          items_left:
+                            type: integer
+                            format: int32
+                            description: Total number of items left
+                            readOnly: true
+                            example: 32500
+                          next_set_url:
+                            type: string
+                            description: The URL to use to get the next batch of contacts
+                            readOnly: true
+                            example: https://app.onepagecrm.com/api/v3/contacts/cascade/5d2c8ca59b79b2ead94aa425
         400:
           $ref: '#/components/responses/400'
         401:
@@ -8449,45 +8041,42 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      contacts:
-                        type: array
-                        items:
-                          properties:
-                            contact:
-                              $ref: '#/components/schemas/Contact'
-                            next_actions:
-                              type: array
-                              items:
-                                $ref: '#/components/schemas/Action'
-                            next_action:
-                              $ref: '#/components/schemas/Action'
-                            queued_actions:
-                              type: array
-                              items:
-                                $ref: '#/components/schemas/Action'
-                            next_action_conflicts:
-                              type: array
-                              items: {}
-                              example: []
-                            company:
-                              $ref: '#/components/schemas/Company'
-                      total_count:
-                        $ref: '#/components/schemas/Page_data/properties/total_count'
-                      page:
-                        $ref: '#/components/schemas/Page_data/properties/page'
-                      per_page:
-                        $ref: '#/components/schemas/Page_data/properties/per_page'
-                      max_page:
-                        $ref: '#/components/schemas/Page_data/properties/max_page'
+                      data:
+                        properties:
+                          contacts:
+                            type: array
+                            items:
+                              properties:
+                                contact:
+                                  $ref: '#/components/schemas/Contact'
+                                next_actions:
+                                  type: array
+                                  items:
+                                    $ref: '#/components/schemas/Action'
+                                next_action:
+                                  $ref: '#/components/schemas/Action'
+                                queued_actions:
+                                  type: array
+                                  items:
+                                    $ref: '#/components/schemas/Action'
+                                next_action_conflicts:
+                                  type: array
+                                  items: {}
+                                  example: []
+                                company:
+                                  $ref: '#/components/schemas/Company'
+                          total_count:
+                            $ref: '#/components/schemas/Page_data/properties/total_count'
+                          page:
+                            $ref: '#/components/schemas/Page_data/properties/page'
+                          per_page:
+                            $ref: '#/components/schemas/Page_data/properties/per_page'
+                          max_page:
+                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -8552,45 +8141,42 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      contacts:
-                        type: array
-                        items:
-                          properties:
-                            contact:
-                              $ref: '#/components/schemas/Contact'
-                            next_actions:
-                              type: array
-                              items:
-                                $ref: '#/components/schemas/Action'
-                            next_action:
-                              $ref: '#/components/schemas/Action'
-                            queued_actions:
-                              type: array
-                              items:
-                                $ref: '#/components/schemas/Action'
-                            next_action_conflicts:
-                              type: array
-                              items: {}
-                              example: []
-                            company:
-                              $ref: '#/components/schemas/Company'
-                      total_count:
-                        $ref: '#/components/schemas/Page_data/properties/total_count'
-                      page:
-                        $ref: '#/components/schemas/Page_data/properties/page'
-                      per_page:
-                        $ref: '#/components/schemas/Page_data/properties/per_page'
-                      max_page:
-                        $ref: '#/components/schemas/Page_data/properties/max_page'
+                      data:
+                        properties:
+                          contacts:
+                            type: array
+                            items:
+                              properties:
+                                contact:
+                                  $ref: '#/components/schemas/Contact'
+                                next_actions:
+                                  type: array
+                                  items:
+                                    $ref: '#/components/schemas/Action'
+                                next_action:
+                                  $ref: '#/components/schemas/Action'
+                                queued_actions:
+                                  type: array
+                                  items:
+                                    $ref: '#/components/schemas/Action'
+                                next_action_conflicts:
+                                  type: array
+                                  items: {}
+                                  example: []
+                                company:
+                                  $ref: '#/components/schemas/Company'
+                          total_count:
+                            $ref: '#/components/schemas/Page_data/properties/total_count'
+                          page:
+                            $ref: '#/components/schemas/Page_data/properties/page'
+                          per_page:
+                            $ref: '#/components/schemas/Page_data/properties/per_page'
+                          max_page:
+                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -8620,29 +8206,26 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      notifications:
-                        type: array
-                        items:
-                          properties:
-                            notification:
-                              $ref: '#/components/schemas/Notification'
-                      total_count:
-                        $ref: '#/components/schemas/Page_data/properties/total_count'
-                      page:
-                        $ref: '#/components/schemas/Page_data/properties/page'
-                      per_page:
-                        $ref: '#/components/schemas/Page_data/properties/per_page'
-                      max_page:
-                        $ref: '#/components/schemas/Page_data/properties/max_page'
+                      data:
+                        properties:
+                          notifications:
+                            type: array
+                            items:
+                              properties:
+                                notification:
+                                  $ref: '#/components/schemas/Notification'
+                          total_count:
+                            $ref: '#/components/schemas/Page_data/properties/total_count'
+                          page:
+                            $ref: '#/components/schemas/Page_data/properties/page'
+                          per_page:
+                            $ref: '#/components/schemas/Page_data/properties/per_page'
+                          max_page:
+                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -8669,17 +8252,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      notification:
-                        $ref: '#/components/schemas/Notification'
+                      data:
+                        properties:
+                          notification:
+                            $ref: '#/components/schemas/Notification'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -8706,17 +8286,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      notification:
-                        $ref: '#/components/schemas/Notification'
+                      data:
+                        properties:
+                          notification:
+                            $ref: '#/components/schemas/Notification'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -8742,15 +8319,12 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
-                    type: object
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
         400:
           $ref: '#/components/responses/400'
         401:
@@ -8776,27 +8350,24 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      webhooks:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Webhook'
-                      total_count:
-                        $ref: '#/components/schemas/Page_data/properties/total_count'
-                      page:
-                        $ref: '#/components/schemas/Page_data/properties/page'
-                      per_page:
-                        $ref: '#/components/schemas/Page_data/properties/per_page'
-                      max_page:
-                        $ref: '#/components/schemas/Page_data/properties/max_page'
+                      data:
+                        properties:
+                          webhooks:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Webhook'
+                          total_count:
+                            $ref: '#/components/schemas/Page_data/properties/total_count'
+                          page:
+                            $ref: '#/components/schemas/Page_data/properties/page'
+                          per_page:
+                            $ref: '#/components/schemas/Page_data/properties/per_page'
+                          max_page:
+                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -8823,15 +8394,12 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
-                    $ref: '#/components/schemas/Webhook'
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/Webhook'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -8879,29 +8447,26 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      pipelines:
-                        type: array
-                        items:
-                          properties:
-                            pipeline:
-                              $ref: '#/components/schemas/Pipeline'
-                      total_count:
-                        $ref: '#/components/schemas/Page_data/properties/total_count'
-                      page:
-                        $ref: '#/components/schemas/Page_data/properties/page'
-                      per_page:
-                        $ref: '#/components/schemas/Page_data/properties/per_page'
-                      max_page:
-                        $ref: '#/components/schemas/Page_data/properties/max_page'
+                      data:
+                        properties:
+                          pipelines:
+                            type: array
+                            items:
+                              properties:
+                                pipeline:
+                                  $ref: '#/components/schemas/Pipeline'
+                          total_count:
+                            $ref: '#/components/schemas/Page_data/properties/total_count'
+                          page:
+                            $ref: '#/components/schemas/Page_data/properties/page'
+                          per_page:
+                            $ref: '#/components/schemas/Page_data/properties/per_page'
+                          max_page:
+                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -8928,17 +8493,14 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  status:
-                    $ref: '#/components/schemas/Success/properties/status'
-                  message:
-                    $ref: '#/components/schemas/Success/properties/message'
-                  timestamp:
-                    $ref: '#/components/schemas/Success/properties/timestamp'
-                  data:
+                allOf:
+                  - $ref: '#/components/schemas/ResponseEnvelope'
+                  - type: object
                     properties:
-                      pipeline:
-                        $ref: '#/components/schemas/Pipeline'
+                      data:
+                        properties:
+                          pipeline:
+                            $ref: '#/components/schemas/Pipeline'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -11622,8 +11184,8 @@ components:
           format: int32
           description: The time the sales reminder time is to be sent (assuming the criteria is met)
           example: 6
-    Success:
-      description: Structure of response for successful request.
+    ResponseEnvelope:
+      description: Standard envelope wrapping every successful API response.
       properties:
         status:
           type: integer
@@ -11642,17 +11204,6 @@ components:
           description: Response time
           readOnly: true
           example: 1528373119
-        data:
-          type: object
-          properties:
-            total_count:
-              $ref: '#/components/schemas/Page_data/properties/total_count'
-            page:
-              $ref: '#/components/schemas/Page_data/properties/page'
-            per_page:
-              $ref: '#/components/schemas/Page_data/properties/per_page'
-            max_page:
-              $ref: '#/components/schemas/Page_data/properties/max_page'
     Page_data:
       description: Pagination meta-data related to response.
       properties:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -888,17 +888,11 @@ paths:
                           deal_fields:
                             type: array
                             items:
+                              allOf:
+                                - $ref: '#/components/schemas/Page_data'
                               properties:
                                 deal_field:
                                   $ref: '#/components/schemas/Deal_field'
-                                total_count:
-                                  $ref: '#/components/schemas/Page_data/properties/total_count'
-                                page:
-                                  $ref: '#/components/schemas/Page_data/properties/page'
-                                per_page:
-                                  $ref: '#/components/schemas/Page_data/properties/per_page'
-                                max_page:
-                                  $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -1066,6 +1060,8 @@ paths:
                   - type: object
                     properties:
                       data:
+                        allOf:
+                          - $ref: '#/components/schemas/Page_data'
                         properties:
                           custom_fields:
                             type: array
@@ -1073,14 +1069,6 @@ paths:
                               properties:
                                 custom_field:
                                   $ref: '#/components/schemas/Custom_field'
-                          total_count:
-                            $ref: '#/components/schemas/Page_data/properties/total_count'
-                          page:
-                            $ref: '#/components/schemas/Page_data/properties/page'
-                          per_page:
-                            $ref: '#/components/schemas/Page_data/properties/per_page'
-                          max_page:
-                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -1248,6 +1236,8 @@ paths:
                   - type: object
                     properties:
                       data:
+                        allOf:
+                          - $ref: '#/components/schemas/Page_data'
                         properties:
                           company_fields:
                             type: array
@@ -1255,14 +1245,6 @@ paths:
                               properties:
                                 company_field:
                                   $ref: '#/components/schemas/Company_field'
-                          total_count:
-                            $ref: '#/components/schemas/Page_data/properties/total_count'
-                          page:
-                            $ref: '#/components/schemas/Page_data/properties/page'
-                          per_page:
-                            $ref: '#/components/schemas/Page_data/properties/per_page'
-                          max_page:
-                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -2163,6 +2145,8 @@ paths:
                   - type: object
                     properties:
                       data:
+                        allOf:
+                          - $ref: '#/components/schemas/Page_data'
                         properties:
                           notes:
                             type: array
@@ -2170,14 +2154,6 @@ paths:
                               properties:
                                 note:
                                   $ref: '#/components/schemas/Note'
-                          total_count:
-                            $ref: '#/components/schemas/Page_data/properties/total_count'
-                          page:
-                            $ref: '#/components/schemas/Page_data/properties/page'
-                          per_page:
-                            $ref: '#/components/schemas/Page_data/properties/per_page'
-                          max_page:
-                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -2466,6 +2442,8 @@ paths:
                   - type: object
                     properties:
                       data:
+                        allOf:
+                          - $ref: '#/components/schemas/Page_data'
                         properties:
                           calls:
                             type: array
@@ -2473,14 +2451,6 @@ paths:
                               properties:
                                 call:
                                   $ref: '#/components/schemas/Call'
-                          total_count:
-                            $ref: '#/components/schemas/Page_data/properties/total_count'
-                          page:
-                            $ref: '#/components/schemas/Page_data/properties/page'
-                          per_page:
-                            $ref: '#/components/schemas/Page_data/properties/per_page'
-                          max_page:
-                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -2848,6 +2818,8 @@ paths:
                   - type: object
                     properties:
                       data:
+                        allOf:
+                          - $ref: '#/components/schemas/Page_data'
                         properties:
                           meetings:
                             type: array
@@ -2855,14 +2827,6 @@ paths:
                               properties:
                                 meeting:
                                   $ref: '#/components/schemas/Meeting'
-                          total_count:
-                            $ref: '#/components/schemas/Page_data/properties/total_count'
-                          page:
-                            $ref: '#/components/schemas/Page_data/properties/page'
-                          per_page:
-                            $ref: '#/components/schemas/Page_data/properties/per_page'
-                          max_page:
-                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -3160,6 +3124,8 @@ paths:
                   - type: object
                     properties:
                       data:
+                        allOf:
+                          - $ref: '#/components/schemas/Page_data'
                         properties:
                           deals:
                             type: array
@@ -3174,14 +3140,6 @@ paths:
                                     Returned only when `fields=contacts(all)` is supplied.
                                   items:
                                     $ref: '#/components/schemas/Contact'
-                          total_count:
-                            $ref: '#/components/schemas/Page_data/properties/total_count'
-                          page:
-                            $ref: '#/components/schemas/Page_data/properties/page'
-                          per_page:
-                            $ref: '#/components/schemas/Page_data/properties/per_page'
-                          max_page:
-                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -3892,6 +3850,8 @@ paths:
                   - type: object
                     properties:
                       data:
+                        allOf:
+                          - $ref: '#/components/schemas/Page_data'
                         properties:
                           relationship_types:
                             type: array
@@ -3899,14 +3859,6 @@ paths:
                               properties:
                                 relationship_type:
                                   $ref: '#/components/schemas/Relationship_Type'
-                          total_count:
-                            $ref: '#/components/schemas/Page_data/properties/total_count'
-                          page:
-                            $ref: '#/components/schemas/Page_data/properties/page'
-                          per_page:
-                            $ref: '#/components/schemas/Page_data/properties/per_page'
-                          max_page:
-                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -4160,6 +4112,8 @@ paths:
                   - type: object
                     properties:
                       data:
+                        allOf:
+                          - $ref: '#/components/schemas/Page_data'
                         properties:
                           actions:
                             type: array
@@ -4167,14 +4121,6 @@ paths:
                               properties:
                                 action:
                                   $ref: '#/components/schemas/Action'
-                          total_count:
-                            $ref: '#/components/schemas/Page_data/properties/total_count'
-                          page:
-                            $ref: '#/components/schemas/Page_data/properties/page'
-                          per_page:
-                            $ref: '#/components/schemas/Page_data/properties/per_page'
-                          max_page:
-                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -4587,6 +4533,8 @@ paths:
                   - type: object
                     properties:
                       data:
+                        allOf:
+                          - $ref: '#/components/schemas/Page_data'
                         properties:
                           filters:
                             type: array
@@ -4594,14 +4542,6 @@ paths:
                               properties:
                                 filter:
                                   $ref: '#/components/schemas/Filter'
-                          total_count:
-                            $ref: '#/components/schemas/Page_data/properties/total_count'
-                          page:
-                            $ref: '#/components/schemas/Page_data/properties/page'
-                          per_page:
-                            $ref: '#/components/schemas/Page_data/properties/per_page'
-                          max_page:
-                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -4634,17 +4574,11 @@ paths:
                   - type: object
                     properties:
                       data:
+                        allOf:
+                          - $ref: '#/components/schemas/Page_data'
                         properties:
                           filter:
                             $ref: '#/components/schemas/Filter'
-                          total_count:
-                            $ref: '#/components/schemas/Page_data/properties/total_count'
-                          page:
-                            $ref: '#/components/schemas/Page_data/properties/page'
-                          per_page:
-                            $ref: '#/components/schemas/Page_data/properties/per_page'
-                          max_page:
-                            $ref: '#/components/schemas/Page_data/properties/max_page'
                           contacts:
                             type: array
                             items:
@@ -4688,6 +4622,8 @@ paths:
                   - type: object
                     properties:
                       data:
+                        allOf:
+                          - $ref: '#/components/schemas/Page_data'
                         properties:
                           companies:
                             type: array
@@ -4695,14 +4631,6 @@ paths:
                               properties:
                                 company:
                                   $ref: '#/components/schemas/Company'
-                          total_count:
-                            $ref: '#/components/schemas/Page_data/properties/total_count'
-                          page:
-                            $ref: '#/components/schemas/Page_data/properties/page'
-                          per_page:
-                            $ref: '#/components/schemas/Page_data/properties/per_page'
-                          max_page:
-                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -4847,6 +4775,8 @@ paths:
                   - type: object
                     properties:
                       data:
+                        allOf:
+                          - $ref: '#/components/schemas/Page_data'
                         properties:
                           actions:
                             type: array
@@ -4854,14 +4784,6 @@ paths:
                               properties:
                                 action:
                                   $ref: '#/components/schemas/Action'
-                          total_count:
-                            $ref: '#/components/schemas/Page_data/properties/total_count'
-                          page:
-                            $ref: '#/components/schemas/Page_data/properties/page'
-                          per_page:
-                            $ref: '#/components/schemas/Page_data/properties/per_page'
-                          max_page:
-                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -4907,6 +4829,8 @@ paths:
                   - type: object
                     properties:
                       data:
+                        allOf:
+                          - $ref: '#/components/schemas/Page_data'
                         properties:
                           deals:
                             type: array
@@ -4914,14 +4838,6 @@ paths:
                               properties:
                                 deal:
                                   $ref: '#/components/schemas/Deal'
-                          total_count:
-                            $ref: '#/components/schemas/Page_data/properties/total_count'
-                          page:
-                            $ref: '#/components/schemas/Page_data/properties/page'
-                          per_page:
-                            $ref: '#/components/schemas/Page_data/properties/per_page'
-                          max_page:
-                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -4962,6 +4878,8 @@ paths:
                   - type: object
                     properties:
                       data:
+                        allOf:
+                          - $ref: '#/components/schemas/Page_data'
                         properties:
                           notes:
                             type: array
@@ -4969,14 +4887,6 @@ paths:
                               properties:
                                 note:
                                   $ref: '#/components/schemas/Note'
-                          total_count:
-                            $ref: '#/components/schemas/Page_data/properties/total_count'
-                          page:
-                            $ref: '#/components/schemas/Page_data/properties/page'
-                          per_page:
-                            $ref: '#/components/schemas/Page_data/properties/per_page'
-                          max_page:
-                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -5017,6 +4927,8 @@ paths:
                   - type: object
                     properties:
                       data:
+                        allOf:
+                          - $ref: '#/components/schemas/Page_data'
                         properties:
                           calls:
                             type: array
@@ -5024,14 +4936,6 @@ paths:
                               properties:
                                 call:
                                   $ref: '#/components/schemas/Call'
-                          total_count:
-                            $ref: '#/components/schemas/Page_data/properties/total_count'
-                          page:
-                            $ref: '#/components/schemas/Page_data/properties/page'
-                          per_page:
-                            $ref: '#/components/schemas/Page_data/properties/per_page'
-                          max_page:
-                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -5072,6 +4976,8 @@ paths:
                   - type: object
                     properties:
                       data:
+                        allOf:
+                          - $ref: '#/components/schemas/Page_data'
                         properties:
                           meetings:
                             type: array
@@ -5079,14 +4985,6 @@ paths:
                               properties:
                                 meeting:
                                   $ref: '#/components/schemas/Meeting'
-                          total_count:
-                            $ref: '#/components/schemas/Page_data/properties/total_count'
-                          page:
-                            $ref: '#/components/schemas/Page_data/properties/page'
-                          per_page:
-                            $ref: '#/components/schemas/Page_data/properties/per_page'
-                          max_page:
-                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -5122,6 +5020,8 @@ paths:
                   - type: object
                     properties:
                       data:
+                        allOf:
+                          - $ref: '#/components/schemas/Page_data'
                         properties:
                           linked_contacts:
                             type: array
@@ -5154,14 +5054,6 @@ paths:
                                         type: string
                                         format: bson-id
                                         example: 5aba31e99007ba0f570c92ab
-                          total_count:
-                            $ref: '#/components/schemas/Page_data/properties/total_count'
-                          page:
-                            $ref: '#/components/schemas/Page_data/properties/page'
-                          per_page:
-                            $ref: '#/components/schemas/Page_data/properties/per_page'
-                          max_page:
-                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -5375,6 +5267,8 @@ paths:
                 allOf:
                   - $ref: '#/components/schemas/ResponseEnvelope'
                   - type: object
+                    allOf:
+                      - $ref: '#/components/schemas/Page_data'
                     properties:
                       data:
                         properties:
@@ -5382,14 +5276,6 @@ paths:
                             type: array
                             items:
                               $ref: '#/components/schemas/Attachment'
-                      total_count:
-                        $ref: '#/components/schemas/Page_data/properties/total_count'
-                      page:
-                        $ref: '#/components/schemas/Page_data/properties/page'
-                      per_page:
-                        $ref: '#/components/schemas/Page_data/properties/per_page'
-                      max_page:
-                        $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -5537,6 +5423,8 @@ paths:
                   - type: object
                     properties:
                       data:
+                        allOf:
+                          - $ref: '#/components/schemas/Page_data'
                         properties:
                           contacts:
                             type: array
@@ -5585,14 +5473,6 @@ paths:
                                   description: Returned only when `fields=pinned_attachments(all)` is supplied. Full attachment objects.
                                   items:
                                     $ref: '#/components/schemas/Attachment'
-                          total_count:
-                            $ref: '#/components/schemas/Page_data/properties/total_count'
-                          page:
-                            $ref: '#/components/schemas/Page_data/properties/page'
-                          per_page:
-                            $ref: '#/components/schemas/Page_data/properties/per_page'
-                          max_page:
-                            $ref: '#/components/schemas/Page_data/properties/max_page'
                       lead_sources:
                         type: array
                         items:
@@ -6155,17 +6035,11 @@ paths:
                   - type: object
                     properties:
                       data:
+                        allOf:
+                          - $ref: '#/components/schemas/Page_data'
                         properties:
                           filter:
                             $ref: '#/components/schemas/Filter'
-                          total_count:
-                            $ref: '#/components/schemas/Page_data/properties/total_count'
-                          page:
-                            $ref: '#/components/schemas/Page_data/properties/page'
-                          per_page:
-                            $ref: '#/components/schemas/Page_data/properties/per_page'
-                          max_page:
-                            $ref: '#/components/schemas/Page_data/properties/max_page'
                           contacts:
                             type: array
                             items:
@@ -6328,6 +6202,8 @@ paths:
                   - type: object
                     properties:
                       data:
+                        allOf:
+                          - $ref: '#/components/schemas/Page_data'
                         properties:
                           actions:
                             type: array
@@ -6335,14 +6211,6 @@ paths:
                               properties:
                                 action:
                                   $ref: '#/components/schemas/Action'
-                          total_count:
-                            $ref: '#/components/schemas/Page_data/properties/total_count'
-                          page:
-                            $ref: '#/components/schemas/Page_data/properties/page'
-                          per_page:
-                            $ref: '#/components/schemas/Page_data/properties/per_page'
-                          max_page:
-                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -6439,6 +6307,8 @@ paths:
                   - type: object
                     properties:
                       data:
+                        allOf:
+                          - $ref: '#/components/schemas/Page_data'
                         properties:
                           deals:
                             type: array
@@ -6446,14 +6316,6 @@ paths:
                               properties:
                                 deal:
                                   $ref: '#/components/schemas/Deal'
-                          total_count:
-                            $ref: '#/components/schemas/Page_data/properties/total_count'
-                          page:
-                            $ref: '#/components/schemas/Page_data/properties/page'
-                          per_page:
-                            $ref: '#/components/schemas/Page_data/properties/per_page'
-                          max_page:
-                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -6580,6 +6442,8 @@ paths:
                   - type: object
                     properties:
                       data:
+                        allOf:
+                          - $ref: '#/components/schemas/Page_data'
                         properties:
                           notes:
                             type: array
@@ -6587,14 +6451,6 @@ paths:
                               properties:
                                 note:
                                   $ref: '#/components/schemas/Note'
-                          total_count:
-                            $ref: '#/components/schemas/Page_data/properties/total_count'
-                          page:
-                            $ref: '#/components/schemas/Page_data/properties/page'
-                          per_page:
-                            $ref: '#/components/schemas/Page_data/properties/per_page'
-                          max_page:
-                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -6690,6 +6546,8 @@ paths:
                   - type: object
                     properties:
                       data:
+                        allOf:
+                          - $ref: '#/components/schemas/Page_data'
                         properties:
                           calls:
                             type: array
@@ -6697,14 +6555,6 @@ paths:
                               properties:
                                 call:
                                   $ref: '#/components/schemas/Call'
-                          total_count:
-                            $ref: '#/components/schemas/Page_data/properties/total_count'
-                          page:
-                            $ref: '#/components/schemas/Page_data/properties/page'
-                          per_page:
-                            $ref: '#/components/schemas/Page_data/properties/per_page'
-                          max_page:
-                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -6803,6 +6653,8 @@ paths:
                   - type: object
                     properties:
                       data:
+                        allOf:
+                          - $ref: '#/components/schemas/Page_data'
                         properties:
                           meetings:
                             type: array
@@ -6810,14 +6662,6 @@ paths:
                               properties:
                                 meeting:
                                   $ref: '#/components/schemas/Meeting'
-                          total_count:
-                            $ref: '#/components/schemas/Page_data/properties/total_count'
-                          page:
-                            $ref: '#/components/schemas/Page_data/properties/page'
-                          per_page:
-                            $ref: '#/components/schemas/Page_data/properties/per_page'
-                          max_page:
-                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -6917,6 +6761,8 @@ paths:
                   - type: object
                     properties:
                       data:
+                        allOf:
+                          - $ref: '#/components/schemas/Page_data'
                         properties:
                           relationships:
                             type: array
@@ -6924,14 +6770,6 @@ paths:
                               properties:
                                 relationship:
                                   $ref: '#/components/schemas/Relationship'
-                          total_count:
-                            $ref: '#/components/schemas/Page_data/properties/total_count'
-                          page:
-                            $ref: '#/components/schemas/Page_data/properties/page'
-                          per_page:
-                            $ref: '#/components/schemas/Page_data/properties/per_page'
-                          max_page:
-                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -7821,6 +7659,8 @@ paths:
                 allOf:
                   - $ref: '#/components/schemas/ResponseEnvelope'
                   - type: object
+                    allOf:
+                      - $ref: '#/components/schemas/Page_data'
                     properties:
                       data:
                         properties:
@@ -7828,14 +7668,6 @@ paths:
                             type: array
                             items:
                               $ref: '#/components/schemas/Attachment'
-                      total_count:
-                        $ref: '#/components/schemas/Page_data/properties/total_count'
-                      page:
-                        $ref: '#/components/schemas/Page_data/properties/page'
-                      per_page:
-                        $ref: '#/components/schemas/Page_data/properties/per_page'
-                      max_page:
-                        $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -8046,6 +7878,8 @@ paths:
                   - type: object
                     properties:
                       data:
+                        allOf:
+                          - $ref: '#/components/schemas/Page_data'
                         properties:
                           contacts:
                             type: array
@@ -8069,14 +7903,6 @@ paths:
                                   example: []
                                 company:
                                   $ref: '#/components/schemas/Company'
-                          total_count:
-                            $ref: '#/components/schemas/Page_data/properties/total_count'
-                          page:
-                            $ref: '#/components/schemas/Page_data/properties/page'
-                          per_page:
-                            $ref: '#/components/schemas/Page_data/properties/per_page'
-                          max_page:
-                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -8146,6 +7972,8 @@ paths:
                   - type: object
                     properties:
                       data:
+                        allOf:
+                          - $ref: '#/components/schemas/Page_data'
                         properties:
                           contacts:
                             type: array
@@ -8169,14 +7997,6 @@ paths:
                                   example: []
                                 company:
                                   $ref: '#/components/schemas/Company'
-                          total_count:
-                            $ref: '#/components/schemas/Page_data/properties/total_count'
-                          page:
-                            $ref: '#/components/schemas/Page_data/properties/page'
-                          per_page:
-                            $ref: '#/components/schemas/Page_data/properties/per_page'
-                          max_page:
-                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -8211,6 +8031,8 @@ paths:
                   - type: object
                     properties:
                       data:
+                        allOf:
+                          - $ref: '#/components/schemas/Page_data'
                         properties:
                           notifications:
                             type: array
@@ -8218,14 +8040,6 @@ paths:
                               properties:
                                 notification:
                                   $ref: '#/components/schemas/Notification'
-                          total_count:
-                            $ref: '#/components/schemas/Page_data/properties/total_count'
-                          page:
-                            $ref: '#/components/schemas/Page_data/properties/page'
-                          per_page:
-                            $ref: '#/components/schemas/Page_data/properties/per_page'
-                          max_page:
-                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -8355,19 +8169,13 @@ paths:
                   - type: object
                     properties:
                       data:
+                        allOf:
+                          - $ref: '#/components/schemas/Page_data'
                         properties:
                           webhooks:
                             type: array
                             items:
                               $ref: '#/components/schemas/Webhook'
-                          total_count:
-                            $ref: '#/components/schemas/Page_data/properties/total_count'
-                          page:
-                            $ref: '#/components/schemas/Page_data/properties/page'
-                          per_page:
-                            $ref: '#/components/schemas/Page_data/properties/per_page'
-                          max_page:
-                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:
@@ -8452,6 +8260,8 @@ paths:
                   - type: object
                     properties:
                       data:
+                        allOf:
+                          - $ref: '#/components/schemas/Page_data'
                         properties:
                           pipelines:
                             type: array
@@ -8459,14 +8269,6 @@ paths:
                               properties:
                                 pipeline:
                                   $ref: '#/components/schemas/Pipeline'
-                          total_count:
-                            $ref: '#/components/schemas/Page_data/properties/total_count'
-                          page:
-                            $ref: '#/components/schemas/Page_data/properties/page'
-                          per_page:
-                            $ref: '#/components/schemas/Page_data/properties/per_page'
-                          max_page:
-                            $ref: '#/components/schemas/Page_data/properties/max_page'
         400:
           $ref: '#/components/responses/400'
         401:


### PR DESCRIPTION
Stacked on #49. Idiomatic de-duplication of the two repeated response structures. **Single-file** (no split — decided against it for now).

**Result:** `swagger.yaml` 12,841 → 12,122 lines (−719), **0 lint errors**, bundle valid. Semantically identical by construction (disjoint `allOf`), verified via lint + bundle + dereference-diff.

### Commits
1. **Response envelope → `allOf: [ResponseEnvelope, {data…}]`** — replaces the per-response `status`/`message`/`timestamp` property-ref triple on 146 responses (8 lines → 5). Removes 438 refs + the now-dead `Success` schema.
2. **Pagination → `allOf: [Page_data]`** — 33 list responses; replaces the 4-field `total_count`/`page`/`per_page`/`max_page` ref block with a single `allOf`.

### Not included
The earlier field-promotion commit (80 `Deal_amount`-style components) was **dropped** — it only served the abandoned multi-file split and added clutter with no single-file benefit.
