### PR TITLE
update swagger docs for API locked actions | CRM-26266

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -4538,9 +4538,10 @@ paths:
       operationId: unlinkAction
       summary: Unlink an action from the external event it mirrors
       description: >-
-        Detaches an action whose `externally_controlled` flag is true, making it an ordinary action
-        whose date, time, status and completion you can change again. Nothing is sent to the external
-        provider — unlinking does not cancel or change the meeting there.
+        Detaches an action whose `externally_controlled` flag is true, making it an ordinary action:
+        `text`, `date`, `exact_time`, `status` and `done` become writable again, and it can be
+        completed or deleted. Nothing is sent to the external provider — unlinking does not cancel
+        or change the meeting there.
       tags:
       - Actions
       parameters:
@@ -9546,9 +9547,10 @@ components:
           type: boolean
           description: >-
             True while this action mirrors an external event (for example a booked meeting) that has
-            not happened yet. Its `date`, `exact_time`, `status` and completion are owned by the
-            external provider. Call `PUT /actions/{action_id}/unlink` to detach the action and regain
-            full control. The flag clears by itself once the event time has passed.
+            not happened yet. Such an action cannot be rescheduled, completed or deleted — it can
+            only be reassigned. The external provider owns `text`, `date`, `exact_time`, `status`
+            and `done`. Call `PUT /actions/{action_id}/unlink` to detach the action and regain full
+            control. The flag clears by itself once the event time has passed.
           readOnly: true
           example: false
         created_at:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -4533,6 +4533,47 @@ paths:
           $ref: '#/components/responses/409'
         500:
           $ref: '#/components/responses/500'
+  /actions/{action_id}/unlink:
+    put:
+      operationId: unlinkAction
+      summary: Unlink an action from the external event it mirrors
+      description: >-
+        Detaches an action whose `externally_controlled` flag is true, making it an ordinary action
+        whose date, time, status and completion you can change again. Nothing is sent to the external
+        provider — unlinking does not cancel or change the meeting there.
+      tags:
+      - Actions
+      parameters:
+      - $ref: '#/components/parameters/path_action_id'
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                properties:
+                  status:
+                    $ref: '#/components/schemas/Success/properties/status'
+                  message:
+                    $ref: '#/components/schemas/Success/properties/message'
+                  timestamp:
+                    $ref: '#/components/schemas/Success/properties/timestamp'
+                  data:
+                    properties:
+                      action:
+                        $ref: '#/components/schemas/Action'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        409:
+          $ref: '#/components/responses/409'
+        500:
+          $ref: '#/components/responses/500'
   /actions/{action_id}/promote:
     put:
       operationId: promoteAction
@@ -9501,6 +9542,15 @@ components:
           description: The date the action was completed (only returned, if action complete)
           readOnly: true
           example: '2018-05-16'
+        externally_controlled:
+          type: boolean
+          description: >-
+            True while this action mirrors an external event (for example a booked meeting) that has
+            not happened yet. Its `date`, `exact_time`, `status` and completion are owned by the
+            external provider. Call `PUT /actions/{action_id}/unlink` to detach the action and regain
+            full control. The flag clears by itself once the event time has passed.
+          readOnly: true
+          example: false
         created_at:
           type: string
           format: date-time


### PR DESCRIPTION
https://xap.youtrack.cloud/issue/CRM-26266/Calendly-Int-API-action-lock-contract-update-before-grace-period